### PR TITLE
Fix 401 error in swagger

### DIFF
--- a/CharlieBackend.Api/Startup.cs
+++ b/CharlieBackend.Api/Startup.cs
@@ -90,7 +90,7 @@ namespace CharlieBackend.Api
                 c.OperationFilter<SecurityRequirementsOperationFilter>();
                 c.IncludeXmlComments(xmlPath); 
 
-                c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
                 {
                     Description = "Specify a Bearer token. \nExample: Bearer yJhbGciOiJIUzI1iIsInR5cCI6IkpXVCJ9",
                     Name = "Authorization",


### PR DESCRIPTION
Fixed 401 error in Swagger.
Itr happened due to c.OperationFilter SecurityRequirementsOperationFilter (); rewrites internal security type name.
#182