### PR TITLE
Feature/add sorting for get attachment

### DIFF
--- a/CharlieBackend.Api/Controllers/AttachmentsController.cs
+++ b/CharlieBackend.Api/Controllers/AttachmentsController.cs
@@ -47,7 +47,7 @@ namespace CharlieBackend.Api.Controllers
         /// </summary>
         /// <param name="request">
         /// Returns list of attachments depending on the user role i.e admin and secretary can see all attachemnts, mentors only for the related groups and students only for themselves
-        /// Mention course id/ group id/ student id or date range to sort the result (non required params)</param>
+        /// Mention course id/ group id/ account ID of a student or date range to sort the result (non required params)</param>
         [SwaggerResponse(200, type: typeof(AttachmentDto))]
         [Authorize(Roles = "Admin, Secretary, Mentor, Student")]
         [HttpPost("attachments")]

--- a/CharlieBackend.Api/Controllers/AttachmentsController.cs
+++ b/CharlieBackend.Api/Controllers/AttachmentsController.cs
@@ -1,8 +1,10 @@
 ﻿using CharlieBackend.Core;
+using CharlieBackend.Core.DTO.Attachment;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authorization;
+using Swashbuckle.AspNetCore.Annotations;
 using CharlieBackend.Business.Services.Interfaces;
 
 namespace CharlieBackend.Api.Controllers
@@ -41,13 +43,17 @@ namespace CharlieBackend.Api.Controllers
         }
 
         /// <summary>
-        /// GET: api/attachments
+        /// Gets relevant attachments
         /// </summary>
+        /// <param name="request"/>
+        /// Returns list of attachments depending on the user role i.e admin and secretary can see all attachemnts, mentors only for the related groups and students only for themselves
+        /// Mention course id/ group id/ student id or date range to sort the result (non required params)
+        [SwaggerResponse(200, type: typeof(AttachmentDto))]
         [Authorize(Roles = "Admin, Secretary, Mentor, Student")]
         [HttpGet]
-        public async Task<IActionResult> GetAttachments()
+        public async Task<IActionResult> GetAttachments([FromBody] AttachmentRequestDTO request)
         {
-            var attachments = await _attachmentService.GetAttachmentsListAsync();
+            var attachments = await _attachmentService.GetAttachmentsListAsync(request);
 
             return attachments.ToActionResult();
         }

--- a/CharlieBackend.Api/Controllers/AttachmentsController.cs
+++ b/CharlieBackend.Api/Controllers/AttachmentsController.cs
@@ -45,15 +45,17 @@ namespace CharlieBackend.Api.Controllers
         /// <summary>
         /// Gets relevant attachments
         /// </summary>
-        /// <param name="request"/>
+        /// <param name="request">
         /// Returns list of attachments depending on the user role i.e admin and secretary can see all attachemnts, mentors only for the related groups and students only for themselves
-        /// Mention course id/ group id/ student id or date range to sort the result (non required params)
+        /// Mention course id/ group id/ student id or date range to sort the result (non required params)</param>
         [SwaggerResponse(200, type: typeof(AttachmentDto))]
         [Authorize(Roles = "Admin, Secretary, Mentor, Student")]
-        [HttpGet]
-        public async Task<IActionResult> GetAttachments([FromBody] AttachmentRequestDTO request)
+        [HttpPost("attachments")]
+        public async Task<IActionResult> GetAttachments([FromBody]AttachmentRequestDto request)
         {
-            var attachments = await _attachmentService.GetAttachmentsListAsync(request);
+            var userData = HttpContext.User;
+
+            var attachments = await _attachmentService.GetAttachmentsListAsync(request, userData);
 
             return attachments.ToActionResult();
         }

--- a/CharlieBackend.Api/SwaggerExamples/AttachmentController/GetAttachmentRequest.cs
+++ b/CharlieBackend.Api/SwaggerExamples/AttachmentController/GetAttachmentRequest.cs
@@ -14,7 +14,7 @@ namespace CharlieBackend.Api.SwaggerExamples.AttachmentController
             {
                 CourseID = 0,
                 GroupID = 0,
-                StudentID = 0,
+                StudentAccountID = 0,
                 StartDate = DateTime.Now,
                 FinishDate = DateTime.Now
             };

--- a/CharlieBackend.Api/SwaggerExamples/AttachmentController/GetAttachmentRequest.cs
+++ b/CharlieBackend.Api/SwaggerExamples/AttachmentController/GetAttachmentRequest.cs
@@ -1,0 +1,23 @@
+﻿using CharlieBackend.Core.DTO.Attachment;
+using CharlieBackend.Core.Entities;
+using Swashbuckle.AspNetCore.Filters;
+using System;
+using System.Collections.Generic;
+
+namespace CharlieBackend.Api.SwaggerExamples.AttachmentController
+{
+    internal class GetAttachmentRequest : IExamplesProvider<AttachmentRequestDto>
+    {
+        public AttachmentRequestDto GetExamples()
+        {
+            return new AttachmentRequestDto
+            {
+                CourseID = 0,
+                GroupID = 0,
+                StudentID = 0,
+                StartDate = DateTime.Now,
+                FinishDate = DateTime.Now
+            };
+        }
+    }
+}

--- a/CharlieBackend.Business/Services/AttachmentService.cs
+++ b/CharlieBackend.Business/Services/AttachmentService.cs
@@ -78,7 +78,7 @@ namespace CharlieBackend.Business.Services
                 
         }
 
-        public async Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync()
+        public async Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync(AttachmentRequestDTO request)
         {
             var attachments = _mapper.Map<IList<AttachmentDto>>(
                         await _unitOfWork.AttachmentRepository.GetAllAsync());

--- a/CharlieBackend.Business/Services/AttachmentService.cs
+++ b/CharlieBackend.Business/Services/AttachmentService.cs
@@ -88,15 +88,16 @@ namespace CharlieBackend.Business.Services
             }
 
             long accountId = Convert.ToInt64(userData.Claims.First(x => x.Type.EndsWith("AccountId")).Value);
+            var result = new List<AttachmentDto>();
 
             if (userData.IsInRole(UserRole.Student.ToString()))
             {
-                var result = await _unitOfWork.AttachmentRepository
+                result = await _unitOfWork.AttachmentRepository
                     .GetAttachmentList(accountId, null, null, accountId, request.StartDate, request.FinishDate);
             }
             else
             {
-                var result = await _unitOfWork.AttachmentRepository
+                result = await _unitOfWork.AttachmentRepository
                     .GetAttachmentList(accountId, request.CourseID, request.GroupID, accountId, request.StartDate, request.FinishDate);
             }
 

--- a/CharlieBackend.Business/Services/Interfaces/IAttachmentService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/IAttachmentService.cs
@@ -15,7 +15,7 @@ namespace CharlieBackend.Business.Services.Interfaces
                     ClaimsPrincipal claimsContext
                     );
 
-        Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync();
+        Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync(AttachmentRequestDTO request);
 
         Task<Result<DownloadAttachmentDto>> DownloadAttachmentAsync(long attachmentId);
 

--- a/CharlieBackend.Business/Services/Interfaces/IAttachmentService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/IAttachmentService.cs
@@ -15,7 +15,7 @@ namespace CharlieBackend.Business.Services.Interfaces
                     ClaimsPrincipal claimsContext
                     );
 
-        Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync(AttachmentRequestDTO request);
+        Task<Result<IList<AttachmentDto>>> GetAttachmentsListAsync(AttachmentRequestDto request, ClaimsPrincipal userdata);
 
         Task<Result<DownloadAttachmentDto>> DownloadAttachmentAsync(long attachmentId);
 

--- a/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
+++ b/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace CharlieBackend.Core.DTO.Attachment
 {
-    public class AttachmentRequestDTO
+    public class AttachmentRequestDto
     {
         public long? CourseID;
 

--- a/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
+++ b/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
@@ -9,7 +9,7 @@ namespace CharlieBackend.Core.DTO.Attachment
 
         public long? GroupID;
 
-        public long? StudentID;
+        public long? StudentAccountID;
 
         [DataType(DataType.DateTime)]
         public DateTime? StartDate;

--- a/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
+++ b/CharlieBackend.Core/DTO/Attachment/AttachmentRequestDTO.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace CharlieBackend.Core.DTO.Attachment
+{
+    public class AttachmentRequestDTO
+    {
+        public long? CourseID;
+
+        public long? GroupID;
+
+        public long? StudentID;
+
+        [DataType(DataType.DateTime)]
+        public DateTime? StartDate;
+
+        [DataType(DataType.DateTime)]
+        public DateTime? FinishDate;
+    }
+}

--- a/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
@@ -22,7 +22,8 @@ namespace CharlieBackend.Data.Repositories.Impl
                                                                 DateTime? startDate, DateTime? finishDate)
         {
             return await _applicationContext.Attachments
-                    .WhereIf(_applicationContext.Accounts.Find(accountId).Role == UserRole.Mentor, x => _applicationContext.Mentors
+                    .WhereIf(_applicationContext.Accounts.Find(accountId) != default 
+                                    && _applicationContext.Accounts.Find(accountId).Role == UserRole.Mentor, x => _applicationContext.Mentors
                         .FirstOrDefault(y => y.AccountId == accountId).MentorsOfStudentGroups
                         .Select(f => f.StudentGroup)
                         .SelectMany(f => f.StudentsOfStudentGroups)

--- a/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
@@ -18,7 +18,7 @@ namespace CharlieBackend.Data.Repositories.Impl
         {
         }
 
-        public async Task<List<AttachmentDto>> GetAttachmentList(long accountId, long? courseId, long? groupId, long? requestedStudentId, 
+        public async Task<List<AttachmentDto>> GetAttachmentList(long accountId, long? courseId, long? groupId, long? requestedStudentAccountId, 
                                                                 DateTime? startDate, DateTime? finishDate)
         {
             return await _applicationContext.Attachments
@@ -36,8 +36,8 @@ namespace CharlieBackend.Data.Repositories.Impl
                         .Where(y => y.StudentGroupId == groupId)
                         .Select(y => y.Student.AccountId)
                         .Contains(x.CreatedByAccountId))
-                    .WhereIf(requestedStudentId != default && requestedStudentId != 0, x => _applicationContext.Students
-                        .Where(y => y.AccountId == requestedStudentId)
+                    .WhereIf(requestedStudentAccountId != default && requestedStudentAccountId != 0, x => _applicationContext.Students
+                        .Where(y => y.AccountId == requestedStudentAccountId)
                         .Select(y => y.AccountId)
                         .Contains(x.CreatedByAccountId))
                     .WhereIf(startDate != default, x => x.CreatedOn >= startDate)

--- a/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/AttachmentRepository.cs
@@ -1,9 +1,13 @@
 ﻿using System.Threading.Tasks;
 using CharlieBackend.Core.Entities;
+using CharlieBackend.Core;
 using Microsoft.EntityFrameworkCore;
 using CharlieBackend.Data.Repositories.Impl.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
+using System;
+
+using CharlieBackend.Core.DTO.Attachment;
 
 namespace CharlieBackend.Data.Repositories.Impl
 {
@@ -12,6 +16,41 @@ namespace CharlieBackend.Data.Repositories.Impl
         public AttachmentRepository(ApplicationContext applicationContext)
                     : base(applicationContext)
         {
+        }
+
+        public async Task<List<AttachmentDto>> GetAttachmentList(long accountId, long? courseId, long? groupId, long? requestedStudentId, 
+                                                                DateTime? startDate, DateTime? finishDate)
+        {
+            return await _applicationContext.Attachments
+                    .WhereIf(_applicationContext.Accounts.Find(accountId).Role == UserRole.Mentor, x => _applicationContext.Mentors
+                        .FirstOrDefault(y => y.AccountId == accountId).MentorsOfStudentGroups
+                        .Select(f => f.StudentGroup)
+                        .SelectMany(f => f.StudentsOfStudentGroups)
+                        .Select(f => f.Student.AccountId)
+                        .Contains(x.CreatedByAccountId))
+                    .WhereIf(courseId != default && courseId != 0, x => _applicationContext.StudentsOfStudentGroups
+                        .Where(y => y.StudentGroup.CourseId == courseId)
+                        .Select(z => z.Student.AccountId)
+                        .Contains(x.CreatedByAccountId))
+                    .WhereIf(groupId != default && groupId != 0, x => _applicationContext.StudentsOfStudentGroups
+                        .Where(y => y.StudentGroupId == groupId)
+                        .Select(y => y.Student.AccountId)
+                        .Contains(x.CreatedByAccountId))
+                    .WhereIf(requestedStudentId != default && requestedStudentId != 0, x => _applicationContext.Students
+                        .Where(y => y.AccountId == requestedStudentId)
+                        .Select(y => y.AccountId)
+                        .Contains(x.CreatedByAccountId))
+                    .WhereIf(startDate != default, x => x.CreatedOn >= startDate)
+                    .WhereIf(finishDate != default, x => x.CreatedOn <= finishDate)
+                    .Select(x => new AttachmentDto
+                    {
+                        Id = x.Id,
+                        CreatedOn = x.CreatedOn,
+                        CreatedByAccountId = x.CreatedByAccountId,
+                        ContainerName = x.ContainerName,
+                        FileName = x.FileName
+                    })
+                    .ToListAsync(); 
         }
 
         public Task<List<Attachment>> GetAttachmentsByIdsAsync(IList<long> attachmentIds)

--- a/CharlieBackend.Data/Repositories/Impl/Interfaces/IAttachmentRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/Interfaces/IAttachmentRepository.cs
@@ -1,11 +1,16 @@
 ﻿using System.Collections.Generic;
+using System;
 using System.Threading.Tasks;
 using CharlieBackend.Core.Entities;
+using CharlieBackend.Core.DTO.Attachment;
+
 
 namespace CharlieBackend.Data.Repositories.Impl.Interfaces
 {
     public interface IAttachmentRepository : IRepository<Attachment>
     {
+        Task<List<AttachmentDto>> GetAttachmentList(long accountId, long? courseId, long? groupId, long? requestedAccId,
+                                                                DateTime? startDate, DateTime? finishDate);
         Task<List<Attachment>> GetAttachmentsByIdsAsync(IList<long> attachmentIds);
     }
 }


### PR DESCRIPTION
Added sorting option for GetAttachment method

- created attachment request DTO
- sorting options course/group/id (any combination)
- resulting list content depends on the user role requesting the data (i.e admin/secretary gets all the data. mentor only his groups, student-only his own)
- only gets student (homework) attachments
- changed the request to POST from GET