### PR TITLE
Refactored Services and Util in AdminPanel

### DIFF
--- a/CharlieBackend.AdminPanel/Controllers/AccountController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/AccountController.cs
@@ -44,9 +44,7 @@ namespace CharlieBackend.AdminPanel.Controllers
         [HttpPost]
         public async Task<IActionResult> Login(AuthenticationDto authDto)
         {
-            var httpResponseToken = await _apiUtil.SignInAsync($"api/accounts/auth", authDto);
-
-            httpResponseToken = httpResponseToken.Replace("Bearer ", "");
+            var httpResponseToken = (await _apiUtil.SignInAsync($"api/accounts/auth", authDto)).Replace("Bearer ", "");
 
             if (httpResponseToken == null || !await AuthenticateAdmin(httpResponseToken))
             {

--- a/CharlieBackend.AdminPanel/Controllers/AccountController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/AccountController.cs
@@ -18,20 +18,16 @@ namespace CharlieBackend.AdminPanel.Controllers
     [Route("[controller]/[action]")]
     public class AccountController : Controller
     {
-        private readonly ILogger<AccountController> _logger;
-
         private readonly IOptions<ApplicationSettings> _config;
 
         private readonly IApiUtil _apiUtil;
 
         private readonly IDataProtector _protector;
 
-        public AccountController(ILogger<AccountController> logger,
-                                 IOptions<ApplicationSettings> config, 
+        public AccountController(IOptions<ApplicationSettings> config, 
                                  IApiUtil apiUtil, 
                                  IDataProtectionProvider provider)
         {
-            _logger = logger;
             _apiUtil = apiUtil;
 
             _config = config;
@@ -48,9 +44,11 @@ namespace CharlieBackend.AdminPanel.Controllers
         [HttpPost]
         public async Task<IActionResult> Login(AuthenticationDto authDto)
         {
-            var httpResponseToken = await _apiUtil.SignInAsync($"{_config.Value.Urls.Api.Https}/api/accounts/auth", authDto);
+            var httpResponseToken = await _apiUtil.SignInAsync($"api/accounts/auth", authDto);
 
-            if(httpResponseToken == null || !await AuthenticateAdmin(httpResponseToken))
+            httpResponseToken = httpResponseToken.Replace("Bearer ", "");
+
+            if (httpResponseToken == null || !await AuthenticateAdmin(httpResponseToken))
             {
                 return RedirectToAction("Login", "Account");
             }
@@ -71,8 +69,6 @@ namespace CharlieBackend.AdminPanel.Controllers
         private async Task<bool> AuthenticateAdmin(string token)
         {
             var handler = new JwtSecurityTokenHandler();
-
-            token = token.ToString().Replace("Bearer ", "");
 
             var tokenS = handler.ReadToken(token) as JwtSecurityToken;
 

--- a/CharlieBackend.AdminPanel/Controllers/MentorsController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/MentorsController.cs
@@ -16,7 +16,6 @@ namespace CharlieBackend.AdminPanel.Controllers
         public MentorsController(IMentorService mentorService)
         {
             _mentorService = mentorService;
-
         }
 
         public async Task<IActionResult> AllMentors()

--- a/CharlieBackend.AdminPanel/Controllers/UsersController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/UsersController.cs
@@ -14,25 +14,17 @@ namespace CharlieBackend.AdminPanel.Controllers
     [Authorize(Roles = "Admin")]
     public class UsersController : Controller
     {
-
-        private readonly IOptions<ApplicationSettings> _config;
         private readonly IApiUtil _apiUtil;
-        private readonly IDataProtector _protector;
 
-        public UsersController(IOptions<ApplicationSettings> config, 
-                               IApiUtil apiUtil,
-                               IDataProtectionProvider provider)
+        public UsersController(IApiUtil apiUtil)
         {
             _apiUtil = apiUtil;
-
-            _config = config;
-            _protector = provider.CreateProtector(_config.Value.Cookies.SecureKey);
         }
 
         [HttpGet]
         public async Task<ActionResult<IList<AccountDto>>> GetAllAccounts()
         {
-            var accounts = await _apiUtil.GetAsync<IList<AccountDto>>($"{_config.Value.Urls.Api.Https}/api/accounts", _protector.Unprotect(Request.Cookies["accessToken"]));
+            var accounts = await _apiUtil.GetAsync<IList<AccountDto>>($"api/accounts");
 
             return Ok(accounts);
         }

--- a/CharlieBackend.AdminPanel/Services/CourseService.cs
+++ b/CharlieBackend.AdminPanel/Services/CourseService.cs
@@ -15,20 +15,17 @@ namespace CharlieBackend.AdminPanel.Services
     {
         private readonly IApiUtil _apiUtil;
 
-        private readonly IOptions<ApplicationSettings> _config;
-
         private readonly IMapper _mapper;
 
-        public CourseService(IApiUtil apiUtil, IOptions<ApplicationSettings> config, IMapper mapper)
+        public CourseService(IApiUtil apiUtil, IMapper mapper)
         {
             _apiUtil = apiUtil;
-            _config = config;
             _mapper = mapper;
         }
 
-        public async Task<IList<CourseViewModel>> GetAllCoursesAsync(string accessToken)
+        public async Task<IList<CourseViewModel>> GetAllCoursesAsync()
         {
-            var courses =  _mapper.Map<IList<CourseViewModel>>(await _apiUtil.GetAsync<IList<CourseDto>>($"{_config.Value.Urls.Api.Https}/api/courses", accessToken));
+            var courses =  _mapper.Map<IList<CourseViewModel>>(await _apiUtil.GetAsync<IList<CourseDto>>($"api/courses/isActive"));
 
             return courses;
         }

--- a/CharlieBackend.AdminPanel/Services/Interfaces/ICourseService.cs
+++ b/CharlieBackend.AdminPanel/Services/Interfaces/ICourseService.cs
@@ -8,6 +8,6 @@ namespace CharlieBackend.AdminPanel.Services.Interfaces
 {
     public interface ICourseService
     {
-        public Task<IList<CourseViewModel>> GetAllCoursesAsync(string accessToken);
+        public Task<IList<CourseViewModel>> GetAllCoursesAsync();
     }
 }

--- a/CharlieBackend.AdminPanel/Services/MentorService.cs
+++ b/CharlieBackend.AdminPanel/Services/MentorService.cs
@@ -17,41 +17,31 @@ namespace CharlieBackend.AdminPanel.Services
     public class MentorService : IMentorService
     {
         private readonly IApiUtil _apiUtil;
-        private readonly IOptions<ApplicationSettings> _config;
-        private readonly IDataProtector _protector;
-        private readonly string _accessToken;
 
-        public MentorService(IApiUtil apiUtil, 
-                             IOptions<ApplicationSettings> config, 
-                             IHttpContextAccessor httpContextAccessor,
-                             IDataProtectionProvider provider)
+        public MentorService(IApiUtil apiUtil)
         {
-            _apiUtil = apiUtil;
-            _config = config;
-            _protector = provider.CreateProtector(_config.Value.Cookies.SecureKey);
-
-            _accessToken = _protector.Unprotect(httpContextAccessor.HttpContext.Request.Cookies["accessToken"]);
+            _apiUtil = apiUtil;    
         }
 
         public async Task<MentorDto> AddMentorAsync(long id)
         {
             return await
-                _apiUtil.CreateAsync<MentorDto>($"{_config.Value.Urls.Api.Https}/api/mentors/{id}", null, _accessToken);
+                _apiUtil.CreateAsync<MentorDto>($"api/mentors/{id}", null);
         }
 
         public async Task<MentorDto> DisableMentorAsync(long id)
         {
             return await 
-                _apiUtil.DeleteAsync<MentorDto>($"{_config.Value.Urls.Api.Https}/api/mentors/{id}", _accessToken);
+                _apiUtil.DeleteAsync<MentorDto>($"api/mentors/{id}");
         }
 
         public async Task<IList<MentorViewModel>> GetAllMentorsAsync()
         {
             var allMentors = await 
-                _apiUtil.GetAsync<IList<MentorViewModel>>($"{_config.Value.Urls.Api.Https}/api/mentors", _accessToken);
+                _apiUtil.GetAsync<IList<MentorViewModel>>($"api/mentors");
 
             var activeMentors = await 
-                _apiUtil.GetAsync<IList<MentorViewModel>>($"{_config.Value.Urls.Api.Https}/api/mentors/active", _accessToken);
+                _apiUtil.GetAsync<IList<MentorViewModel>>($"api/mentors/active");
 
             foreach (var mentor in allMentors)
             {
@@ -63,11 +53,9 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<MentorEditViewModel> GetMentorByIdAsync(long id)
         {
-            var mentorTask = _apiUtil.GetAsync<MentorEditViewModel>($"{_config.Value.Urls.Api.Https}/api/mentors/{id}", _accessToken);
-            var coursesTask = _apiUtil.GetAsync<IList<CourseViewModel>>($"{_config.Value.Urls.Api.Https}/api/courses", _accessToken);
-            var studentGroupTask = _apiUtil.GetAsync<IList<StudentGroupViewModel>>($"{_config.Value.Urls.Api.Https}/api/student_groups", _accessToken);
-
-            var mentor = await mentorTask;
+            var coursesTask = _apiUtil.GetAsync<IList<CourseViewModel>>($"api/courses/isActive");
+            var studentGroupTask = _apiUtil.GetAsync<IList<StudentGroupViewModel>>($"api/student_groups");
+            var mentor = await _apiUtil.GetAsync<MentorEditViewModel>($"api/mentors/{id}");
 
             mentor.AllGroups = await studentGroupTask;
             mentor.AllCourses = await coursesTask;
@@ -78,7 +66,7 @@ namespace CharlieBackend.AdminPanel.Services
         public async Task<UpdateMentorDto> UpdateMentorAsync(long id, UpdateMentorDto UpdateDto)
         {
             return await 
-                _apiUtil.PutAsync($"{_config.Value.Urls.Api.Https}/api/mentors/{id}", UpdateDto, _accessToken);
+                _apiUtil.PutAsync($"api/mentors/{id}", UpdateDto);
         }
     }
 }

--- a/CharlieBackend.AdminPanel/Services/StudentGroupService.cs
+++ b/CharlieBackend.AdminPanel/Services/StudentGroupService.cs
@@ -18,30 +18,20 @@ namespace CharlieBackend.AdminPanel.Services
     {
         private readonly IApiUtil _apiUtil;
         private readonly IMapper _mapper;
-        private readonly IOptions<ApplicationSettings> _config;
-        private readonly IDataProtector _protector;
 
         private readonly IMentorService _mentorService;
         private readonly IStudentService _studentService;
         private readonly ICourseService _courseService;
-        private readonly string _accessToken;
 
         public StudentGroupService(IApiUtil apiUtil,
                                    IMapper mapper,
-                                   IOptions<ApplicationSettings> config,
-                                   IHttpContextAccessor httpContextAccessor,
-                                   IDataProtectionProvider provider,
 
                                    IMentorService mentorService,
                                    IStudentService studentService,
                                    ICourseService courseService)
         {
             _apiUtil = apiUtil;
-            _config = config;
             _mapper = mapper;
-            _protector = provider.CreateProtector(_config.Value.Cookies.SecureKey);
-
-            _accessToken = _protector.Unprotect(httpContextAccessor.HttpContext.Request.Cookies["accessToken"]);
 
             _mentorService = mentorService;
             _studentService = studentService;
@@ -50,15 +40,12 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<IList<StudentGroupViewModel>> GetAllStudentGroupsAsync()
         {
-            var studentGroupsTask = _apiUtil.GetAsync<IList<StudentGroupDto>>($"{_config.Value.Urls.Api.Https}/api/student_groups", _accessToken);
-            var studentsTask = _studentService.GetAllStudentsAsync();
-            var mentorsTask = _mentorService.GetAllMentorsAsync();
-            var coursesTask = _courseService.GetAllCoursesAsync(_accessToken);
-
-            var studentGroups = _mapper.Map<IList<StudentGroupViewModel>>(await studentGroupsTask);
-            var students = await studentsTask;
-            var mentors = await mentorsTask;
-            var courses = await coursesTask;
+            var studentGroupsResponse = await _apiUtil.GetAsync<IList<StudentGroupDto>>($"api/student_groups");
+            var studentGroups = _mapper.Map<IList<StudentGroupViewModel>>(studentGroupsResponse);
+            
+            var students = await _studentService.GetAllStudentsAsync(); ;
+            var mentors = await _mentorService.GetAllMentorsAsync();
+            var courses = await _courseService.GetAllCoursesAsync();
 
             foreach (var item in studentGroups)
             {
@@ -98,10 +85,10 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<StudentGroupEditViewModel> PrepareStudentGroupUpdateAsync(long id)
         {
-            var studentGroupsTask = _apiUtil.GetAsync<StudentGroupDto>($"{_config.Value.Urls.Api.Https}/api/student_groups/{id}", _accessToken);
+            var studentGroupsTask = _apiUtil.GetAsync<StudentGroupDto>($"api/student_groups/{id}");
             var studentsTask = _studentService.GetAllStudentsAsync();
             var mentorsTask = _mentorService.GetAllMentorsAsync();
-            var coursesTask = _courseService.GetAllCoursesAsync(_accessToken);
+            var coursesTask = _courseService.GetAllCoursesAsync();
 
             var studentGroup = _mapper.Map<StudentGroupEditViewModel>(await studentGroupsTask);
             studentGroup.AllCourses = await coursesTask;
@@ -115,7 +102,7 @@ namespace CharlieBackend.AdminPanel.Services
         {
             var studentsTask = _studentService.GetAllStudentsAsync();
             var mentorsTask = _mentorService.GetAllMentorsAsync();
-            var coursesTask = _courseService.GetAllCoursesAsync(_accessToken);
+            var coursesTask = _courseService.GetAllCoursesAsync();
 
             var studentGroup = new StudentGroupEditViewModel
             {
@@ -129,7 +116,7 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<StudentGroupDto> UpdateStudentGroupAsync(long id, StudentGroupDto updateDto)
         {
-            var updateStudentGroupTask = _apiUtil.PutAsync($"{_config.Value.Urls.Api.Https}/api/student_groups/{id}", _mapper.Map<UpdateStudentGroupDto>(updateDto), _accessToken);
+            var updateStudentGroupTask = _apiUtil.PutAsync($"api/student_groups/{id}", _mapper.Map<UpdateStudentGroupDto>(updateDto));
 
 
             await updateStudentGroupTask;
@@ -139,7 +126,7 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<CreateStudentGroupDto> AddStudentGroupAsync(long id, CreateStudentGroupDto addDto)
         {
-            var createStudentGroup = await _apiUtil.CreateAsync($"{_config.Value.Urls.Api.Https}/api/student_groups", addDto, _accessToken);
+            var createStudentGroup = await _apiUtil.CreateAsync($"api/student_groups", addDto);
 
             return createStudentGroup;
         }

--- a/CharlieBackend.AdminPanel/Services/StudentService.cs
+++ b/CharlieBackend.AdminPanel/Services/StudentService.cs
@@ -17,26 +17,15 @@ namespace CharlieBackend.AdminPanel.Services
     {
         private readonly IApiUtil _apiUtil;
 
-        private readonly IOptions<ApplicationSettings> _config;
-        private readonly IDataProtector _protector;
-        private readonly string _accessToken;
-
-        public StudentService(IApiUtil apiUtil,
-                              IOptions<ApplicationSettings> config,
-                              IHttpContextAccessor httpContextAccessor,
-                              IDataProtectionProvider provider)
+        public StudentService(IApiUtil apiUtil)
         {
             _apiUtil = apiUtil;
-            _config = config;
-            _protector = provider.CreateProtector(_config.Value.Cookies.SecureKey);
-
-            _accessToken = _protector.Unprotect(httpContextAccessor.HttpContext.Request.Cookies["accessToken"]);
         }
 
         public async Task<IList<StudentViewModel>> GetAllStudentsAsync()
         {
-            var allStudentsTask =  _apiUtil.GetAsync<IList<StudentViewModel>>($"{_config.Value.Urls.Api.Https}/api/students", _accessToken);
-            var activeStudentsTask = _apiUtil.GetAsync<IList<StudentViewModel>>($"{_config.Value.Urls.Api.Https}/api/students/active", _accessToken);
+            var allStudentsTask =  _apiUtil.GetAsync<IList<StudentViewModel>>($"api/students");
+            var activeStudentsTask = _apiUtil.GetAsync<IList<StudentViewModel>>($"api/students/active");
 
             var allStudents = await allStudentsTask;
             var activeStudents = await activeStudentsTask;
@@ -51,8 +40,8 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<StudentEditViewModel> GetStudentByIdAsync(long id)
         {
-            var studentTask =  _apiUtil.GetAsync<StudentEditViewModel>($"{_config.Value.Urls.Api.Https}/api/students/{id}", _accessToken);
-            var studentGroupsTask = _apiUtil.GetAsync<IList<StudentGroupViewModel>>($"{_config.Value.Urls.Api.Https}/api/student_groups", _accessToken);
+            var studentTask =  _apiUtil.GetAsync<StudentEditViewModel>($"api/students/{id}");
+            var studentGroupsTask = _apiUtil.GetAsync<IList<StudentGroupViewModel>>($"api/student_groups");
 
             var student = await studentTask;
             var studentGroup = await studentGroupsTask;
@@ -64,21 +53,21 @@ namespace CharlieBackend.AdminPanel.Services
 
         public async Task<UpdateStudentDto> UpdateStudentAsync(long id, UpdateStudentDto UpdateDto)
         {
-            var updatedStudent = await _apiUtil.PutAsync($"{_config.Value.Urls.Api.Https}/api/students/{id}", UpdateDto, _accessToken);
+            var updatedStudent = await _apiUtil.PutAsync($"api/students/{id}", UpdateDto);
             
             return updatedStudent;
         }
 
         public async Task<StudentDto> AddStudentAsync(long id)
         {
-            var addedStudentTask = await _apiUtil.CreateAsync<StudentDto>($"{_config.Value.Urls.Api.Https}/api/students/{id}", null, _accessToken);
+            var addedStudentTask = await _apiUtil.CreateAsync<StudentDto>($"api/students/{id}", null);
 
             return addedStudentTask;
         }
 
         public async Task<StudentDto> DisableStudentAsync(long id)
         {
-            var disabledStudent = await _apiUtil.DeleteAsync<StudentDto>($"{_config.Value.Urls.Api.Https}/api/students/{id}", _accessToken);
+            var disabledStudent = await _apiUtil.DeleteAsync<StudentDto>($"api/students/{id}");
 
             return disabledStudent;
         }

--- a/CharlieBackend.AdminPanel/Services/ThemeService.cs
+++ b/CharlieBackend.AdminPanel/Services/ThemeService.cs
@@ -13,44 +13,34 @@ namespace CharlieBackend.AdminPanel.Services
     public class ThemeService : IThemeService
     {
         private readonly IApiUtil _apiUtil;
-        private readonly IOptions<ApplicationSettings> _config;
-        private readonly IDataProtector _protector;
-        private readonly string _accessToken;
 
-        public ThemeService(IApiUtil apiUtil, 
-                            IOptions<ApplicationSettings> config, 
-                            IHttpContextAccessor httpContextAccessor,
-                            IDataProtectionProvider provider)
+        public ThemeService(IApiUtil apiUtil)
         {
             _apiUtil = apiUtil;
-            _config = config;
-            _protector = provider.CreateProtector(_config.Value.Cookies.SecureKey);
-
-            _accessToken = _protector.Unprotect(httpContextAccessor.HttpContext.Request.Cookies["accessToken"]);
         }
 
         public async Task DeleteTheme(long id)
         {
             await
-                _apiUtil.DeleteAsync<ThemeViewModel>($"{_config.Value.Urls.Api.Https}/api/themes/{id}", _accessToken);
+                _apiUtil.DeleteAsync<ThemeViewModel>($"api/themes/{id}");
         }
 
         public async Task UpdateTheme(long id, UpdateThemeDto UpdateDto)
         {
             await
-                _apiUtil.PutAsync<UpdateThemeDto>($"{_config.Value.Urls.Api.Https}/api/themes/{id}", UpdateDto, _accessToken);
+                _apiUtil.PutAsync<UpdateThemeDto>($"api/themes/{id}", UpdateDto);
         }
 
         public async Task<IList<ThemeViewModel>> GetAllThemesAsync()
         {
             return await
-                _apiUtil.GetAsync<IList<ThemeViewModel>>($"{_config.Value.Urls.Api.Https}/api/themes", _accessToken);
+                _apiUtil.GetAsync<IList<ThemeViewModel>>($"api/themes");
         }
 
         public async Task AddThemeAsync(CreateThemeDto themeDto)
         {
             await
-                _apiUtil.CreateAsync<CreateThemeDto>($"{_config.Value.Urls.Api.Https}/api/themes", themeDto, _accessToken);
+                _apiUtil.CreateAsync<CreateThemeDto>($"api/themes", themeDto);
         }
     }
 }

--- a/CharlieBackend.AdminPanel/Startup.cs
+++ b/CharlieBackend.AdminPanel/Startup.cs
@@ -34,30 +34,9 @@ namespace CharlieBackend.AdminPanel
 
             services.AddHttpContextAccessor();
 
-            services.AddScoped<IHttpUtil, HttpUtil>((ctx) =>
-            {
-                IHttpContextAccessor httpContext = ctx.GetService<IHttpContextAccessor>();
-
-                string accessToken = httpContext.HttpContext.Request.Cookies["accessToken"];
-
-                if (accessToken != null)
-                {
-                    IDataProtectionProvider provider = ctx.GetService<IDataProtectionProvider>();
-
-                    IDataProtector protector = provider.CreateProtector(config.Cookies.SecureKey);
-
-                    string unprotectedToken = protector.Unprotect(accessToken);
-
-                    return new HttpUtil(config.Urls.Api.Https, unprotectedToken);
-                }
-                else
-                {
-                    return new HttpUtil(config.Urls.Api.Https);
-                }
-            });
-
-            services.AddTransient<IApiUtil, ApiUtil>();
-
+            services.AddScoped<IHttpUtil, HttpUtil>();
+            services.AddScoped<IApiUtil, ApiUtil>();
+            
             services.AddTransient<IStudentService, StudentService>(); 
             services.AddTransient<IStudentGroupService, StudentGroupService>();
             services.AddTransient<ICourseService, CourseService>();

--- a/CharlieBackend.AdminPanel/Utils/ApiUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/ApiUtil.cs
@@ -36,9 +36,9 @@ namespace CharlieBackend.AdminPanel.Utils
             return token.FirstOrDefault();
         }
 
-        public async Task<T> GetAsync<T>(string url, string accessToken)
+        public async Task<T> GetAsync<T>(string url)
         {
-            var httpResponse = await _httpUtil.GetAsync(url, accessToken);
+            var httpResponse = await _httpUtil.GetAsync(url);
 
             await _httpUtil.EnsureSuccessStatusCode(httpResponse);
 
@@ -50,9 +50,9 @@ namespace CharlieBackend.AdminPanel.Utils
             return responseModel;
         }
 
-        public async Task<T> CreateAsync<T>(string url, T data, string accessToken)
+        public async Task<T> CreateAsync<T>(string url, T data)
         {
-            var httpResponse = await _httpUtil.PostJsonAsync(url, data, accessToken);
+            var httpResponse = await _httpUtil.PostJsonAsync(url, data);
 
             await _httpUtil.EnsureSuccessStatusCode(httpResponse);
 
@@ -63,9 +63,9 @@ namespace CharlieBackend.AdminPanel.Utils
             return responseModel;
         }
 
-        public async Task<T> PutAsync<T>(string url, T data, string accessToken)
+        public async Task<T> PutAsync<T>(string url, T data)
         {
-            var httpResponse = await _httpUtil.PutJsonAsync(url, data, accessToken);
+            var httpResponse = await _httpUtil.PutJsonAsync(url, data);
 
             await _httpUtil.EnsureSuccessStatusCode(httpResponse);
 
@@ -77,9 +77,9 @@ namespace CharlieBackend.AdminPanel.Utils
         }
 
 
-        public async Task<T> DeleteAsync<T>(string url, string accessToken)
+        public async Task<T> DeleteAsync<T>(string url)
         {
-            var httpResponse = await _httpUtil.DeleteAsync(url, accessToken);
+            var httpResponse = await _httpUtil.DeleteAsync(url);
 
             await _httpUtil.EnsureSuccessStatusCode(httpResponse);
 

--- a/CharlieBackend.AdminPanel/Utils/HttpUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/HttpUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -7,6 +7,9 @@ using Newtonsoft.Json;
 using CharlieBackend.AdminPanel.Exceptions;
 using CharlieBackend.Core.DTO.Result;
 using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace CharlieBackend.AdminPanel.Utils
 {

--- a/CharlieBackend.AdminPanel/Utils/HttpUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/HttpUtil.cs
@@ -6,6 +6,7 @@ using CharlieBackend.AdminPanel.Utils.Interfaces;
 using Newtonsoft.Json;
 using CharlieBackend.AdminPanel.Exceptions;
 using CharlieBackend.Core.DTO.Result;
+using System.Net.Http.Headers;
 
 namespace CharlieBackend.AdminPanel.Utils
 {
@@ -13,34 +14,36 @@ namespace CharlieBackend.AdminPanel.Utils
     {
         private readonly HttpClient _client;
 
-        public HttpUtil()
+        public HttpUtil(string baseUrl, string token)
         {
-            _client = new HttpClient();
+            _client = new HttpClient() 
+            { 
+                BaseAddress = new Uri(baseUrl) 
+            };
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
-        public async Task<HttpResponseMessage> GetAsync(string url, string accessToken = null)
+        public HttpUtil(string baseUrl)
+        {
+            _client = new HttpClient() 
+            { 
+                BaseAddress = new Uri(baseUrl) 
+            };
+        }
+
+        public async Task<HttpResponseMessage> GetAsync(string url)
         {
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-
-            if (!String.IsNullOrEmpty(accessToken))
-            {
-                requestMessage.Headers.Add("Authorization", accessToken);
-            }
 
             HttpResponseMessage httpResponse = await _client.SendAsync(requestMessage);
 
             return httpResponse;
         }
 
-        public async Task<HttpResponseMessage> PostJsonAsync<T>(string url, T postData, string accessToken = null)
+        public async Task<HttpResponseMessage> PostJsonAsync<T>(string url, T postData)
         {
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
 
-            if (!String.IsNullOrEmpty(accessToken))
-            {
-                requestMessage.Headers.Add("Authorization", accessToken);
-            }
-
             requestMessage.Content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json");
 
             var responseMessage = await _client.SendAsync(requestMessage);
@@ -48,15 +51,10 @@ namespace CharlieBackend.AdminPanel.Utils
             return responseMessage;
         }
 
-        public async Task<HttpResponseMessage> PutJsonAsync<T>(string url, T postData, string accessToken = null)
+        public async Task<HttpResponseMessage> PutJsonAsync<T>(string url, T postData)
         {
             var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
-            if (!String.IsNullOrEmpty(accessToken))
-            {
-                requestMessage.Headers.Add("Authorization", accessToken);
-            }
-
             requestMessage.Content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json");
 
             var responseMessage = await _client.SendAsync(requestMessage);
@@ -64,13 +62,9 @@ namespace CharlieBackend.AdminPanel.Utils
             return responseMessage;
         }
 
-        public async Task<HttpResponseMessage> DeleteAsync(string url, string accessToken = null)
+        public async Task<HttpResponseMessage> DeleteAsync(string url)
         {
             var requestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
-            if (!String.IsNullOrEmpty(accessToken))
-            {
-                requestMessage.Headers.Add("Authorization", accessToken);
-            }
 
             var responseMessage = await _client.SendAsync(requestMessage);
 

--- a/CharlieBackend.AdminPanel/Utils/Interfaces/IApiUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/Interfaces/IApiUtil.cs
@@ -7,12 +7,12 @@ namespace CharlieBackend.AdminPanel.Utils.Interfaces
     {
         public Task<string> SignInAsync(string url, AuthenticationDto authModel);
 
-        public Task<T> GetAsync<T>(string url, string accessToken);
+        public Task<T> GetAsync<T>(string url);
 
-        public Task<T> CreateAsync<T>(string url, T data, string accessToken);
+        public Task<T> CreateAsync<T>(string url, T data);
 
-        public Task<T> PutAsync<T>(string url, T data, string accessToken);
+        public Task<T> PutAsync<T>(string url, T data);
 
-        public Task<T> DeleteAsync<T>(string url, string accessToken);
+        public Task<T> DeleteAsync<T>(string url);
     }
 }

--- a/CharlieBackend.AdminPanel/Utils/Interfaces/IHttpUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/Interfaces/IHttpUtil.cs
@@ -6,13 +6,13 @@ namespace CharlieBackend.AdminPanel.Utils.Interfaces
 {
     public interface IHttpUtil
     {
-        Task<HttpResponseMessage> GetAsync(string url, string accessToken = null);
+        Task<HttpResponseMessage> GetAsync(string url);
 
-        Task<HttpResponseMessage> PostJsonAsync<T>(string url, T postData, string accessToken = null);
+        Task<HttpResponseMessage> PostJsonAsync<T>(string url, T postData);
 
-        Task<HttpResponseMessage> PutJsonAsync<T>(string url, T postData, string accessToken = null);
+        Task<HttpResponseMessage> PutJsonAsync<T>(string url, T postData);
 
-        Task<HttpResponseMessage> DeleteAsync(string url, string accessToken = null);
+        Task<HttpResponseMessage> DeleteAsync(string url);
 
         Task EnsureSuccessStatusCode(HttpResponseMessage httpResponse);
 


### PR DESCRIPTION
**IApiUtil and IHttpUtil interfaces simplyfied:**

- Token parameter is removed from infaces' methods
- Token obtaining logic is moved to Startup class in ConfigureServices method
- API Url is set to httpclient BaseUrl during initialization of HttpUtil in Startup class

**This resulted into:**

- No need to obtain Token in Services' constructors as it's set to IHttpUtil during initialization
- No need to obtain API Url in Services' method as it's to ser to IHttpUtil during initialization
- No need to pass Token when using IHttpUtil and IApiUtil method