### PR TITLE
Removed AsQueryable from GroupBy request

### DIFF
--- a/CharlieBackend.Data/Repositories/Impl/DashboardRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/DashboardRepository.cs
@@ -215,7 +215,6 @@ namespace CharlieBackend.Data.Repositories.Impl
                         StudentLessonMark = (decimal)x.StudentMark,
                         StudentId = x.StudentId
                     })
-                    .AsQueryable()
                     .GroupBy(x => new
                     {
                         GroupId = x.StudentGroupId,
@@ -316,7 +315,6 @@ namespace CharlieBackend.Data.Repositories.Impl
                     StudentGroupId = (long)x.Lesson.StudentGroupId,
                     StudentMark = (decimal)x.StudentMark
                 })
-                .AsQueryable()
                 .GroupBy(x => new
                 {
                     GroupId = x.StudentGroupId,


### PR DESCRIPTION
AsQueryable was removed from GroupBy request in DashboardRepository because current expression is already IQueryable 