### PR TITLE
Fix to PostScheduleBug

### DIFF
--- a/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
+++ b/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
@@ -47,11 +47,17 @@ namespace CharlieBackend.Business.Services
 
             _unitOfWork.EventOccurrenceRepository.Add(result);
 
-            _unitOfWork.ScheduledEventRepository.AddRange(_scheduledEventFactory.Get(createScheduleRequest.Pattern).GetEvents(result, createScheduleRequest.Context));
-
             await _unitOfWork.CommitAsync();
 
+            await AddEventsAsync(result, createScheduleRequest);
+
             return Result<EventOccurrenceDTO>.GetSuccess(_mapper.Map<EventOccurrenceDTO>(result));
+        }
+
+        private async Task AddEventsAsync(EventOccurrence result, CreateScheduleDto createScheduleRequest)
+        {
+            _unitOfWork.ScheduledEventRepository.AddRange(_scheduledEventFactory.Get(createScheduleRequest.Pattern).GetEvents(result, createScheduleRequest.Context));
+            await _unitOfWork.CommitAsync();
         }
 
         public async Task<Result<EventOccurrenceDTO>> DeleteScheduleByIdAsync(long id, DateTime? startDate, DateTime? finishDate)


### PR DESCRIPTION
Found a bug when creating a schedule related to db context
Events were not created as the initial instance of event occurrence could not have been commited to db in time.

created AddEventsAsync method
