### PR TITLE
Deleted all unnecessary .WithMessage(...) in fluent validation

### DIFF
--- a/CharlieBackend.Api/Validators/AccountDTOValidators/AccountDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/AccountDtoValidator.cs
@@ -12,23 +12,23 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public AccountDtoValidator()
         {
             RuleFor(x => x.Id)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .GreaterThan(0).WithMessage("{PropertyName} must be greater than 0");
+                .NotEmpty()
+                .GreaterThan(0);
             RuleFor(x => x.FirstName)
-                 .NotEmpty().WithMessage("{PropertyName} is required")
-                 .MaximumLength(30).WithMessage("{PropertyName} can't be greater than {MaxLength} symbols");
+                 .NotEmpty()
+                 .MaximumLength(30);
             RuleFor(x => x.LastName)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(30).WithMessage("{PropertyName} can't be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(30);
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.Role)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .IsInEnum().WithMessage("Invalid role");
+                .NotEmpty()
+                .IsInEnum();
             RuleFor(x => x.IsActive)
-                .NotEmpty().WithMessage("{PropertyName} is required");
+                .NotEmpty();
         }
     }
 }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/AuthenticationDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/AuthenticationDtoValidator.cs
@@ -11,12 +11,12 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public AuthenticationDtoValidator()
         {
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("Email cannot be empty")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.Password)
-                .NotEmpty().WithMessage("Password cannot be empty")
-                .MaximumLength(65).WithMessage("Password cannot be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(65);
         }
     }
 }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/ChangeCurrentPasswordDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/ChangeCurrentPasswordDtoValidator.cs
@@ -12,17 +12,17 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public ChangeCurrentPasswordDtoValidator()
         {
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("Email cannot be empty")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.CurrentPassword)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(30).WithMessage("Password cannot be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(30);
             RuleFor(x => x.NewPassword)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(30).WithMessage("Password cannot be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(30);
             RuleFor(x => x.ConfirmNewPassword)
-                .NotEmpty().WithMessage("{PropertyName} is required")
+                .NotEmpty()
                 .Equal(x => x.NewPassword).WithMessage("Passwords does not match");
         }
     }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/ChangeCurrentPasswordDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/ChangeCurrentPasswordDtoValidator.cs
@@ -23,7 +23,7 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
                 .MaximumLength(30);
             RuleFor(x => x.ConfirmNewPassword)
                 .NotEmpty()
-                .Equal(x => x.NewPassword).WithMessage("Passwords does not match");
+                .Equal(x => x.NewPassword).WithMessage("Passwords do not match");
         }
     }
 }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/CreateAccountDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/CreateAccountDtoValidator.cs
@@ -25,7 +25,7 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
                 .MaximumLength(65);
             RuleFor(x => x.ConfirmPassword)
                 .NotEmpty()
-                .Equal(x => x.Password).WithMessage("Passwords does not match");
+                .Equal(x => x.Password).WithMessage("Passwords do not match");
             
         }
     }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/CreateAccountDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/CreateAccountDtoValidator.cs
@@ -11,20 +11,20 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public CreateAccountDtoValidator()
         {
             RuleFor(x => x.FirstName)
-                 .NotEmpty().WithMessage("{PropertyName} is required")
-                 .MaximumLength(30).WithMessage("{PropertyName} can't be greater than {MaxLength} symbols");
+                 .NotEmpty()
+                 .MaximumLength(30);
             RuleFor(x => x.LastName)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(30).WithMessage("{PropertyName} can't be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(30);
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.Password)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(65).WithMessage("Password cannot be greater than {MaxLength} symbols");
+                .NotEmpty()
+                .MaximumLength(65);
             RuleFor(x => x.ConfirmPassword)
-                .NotEmpty().WithMessage("{PropertyName} is required")
+                .NotEmpty()
                 .Equal(x => x.Password).WithMessage("Passwords does not match");
             
         }

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/ForgotPasswordDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/ForgotPasswordDtoValidator.cs
@@ -12,12 +12,12 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public ForgotPasswordDtoValidator()
         {
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.FormUrl)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(200).WithMessage("Url cannot be greateh than {MaxLength} symbols")
+                .NotEmpty()
+                .MaximumLength(200)
                 .Must(BeValidURL);
         }
 

--- a/CharlieBackend.Api/Validators/AccountDTOValidators/ResetPasswordDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/AccountDTOValidators/ResetPasswordDtoValidator.cs
@@ -12,15 +12,15 @@ namespace CharlieBackend.Api.Validators.AccountDTOValidators
         public ResetPasswordDtoValidator()
         {
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .EmailAddress().WithMessage("Incorrect email")
-                .MaximumLength(50).WithMessage("Email cannot be greateh than {MaxLength} symbols");
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(50);
             RuleFor(x => x.NewPassword)
-               .NotEmpty().WithMessage("{PropertyName} is required")
-               .MaximumLength(30).WithMessage("Password cannot be greater than {MaxLength} symbols");
+               .NotEmpty()
+               .MaximumLength(30);
             RuleFor(x => x.ConfirmNewPassword)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .Equal(x => x.NewPassword).WithMessage("Passwords does not match");
+                .NotEmpty()
+                .Equal(x => x.NewPassword);
         }
     }
 }


### PR DESCRIPTION
We don't need to write own messages(.WithMessage(".....")) for every checking.