### PR TITLE
Fix comparison operator in GetEventsFiltered()

### DIFF
--- a/CharlieBackend.Api.UnitTes/ScheduleServiceTests.cs
+++ b/CharlieBackend.Api.UnitTes/ScheduleServiceTests.cs
@@ -43,6 +43,29 @@ namespace CharlieBackend.Api.UnitTest
             _unitOfWorkMock.Setup(x => x.StudentGroupRepository).Returns(_studentGroupRepositoryMock.Object);
         }
 
+        private ScheduledEventFilterRequestDTO Get_ScheduledEventFilterRequestDTO(
+            long? courseId = null,
+            long? mentorId = null,
+            long? groupId = null,
+            long? themeId = null,
+            long? studentAccountId = null,
+            long? EventOccurenceId = null,
+            DateTime? startDate = null,
+            DateTime? finishDate = null)
+        {
+            return new ScheduledEventFilterRequestDTO
+            {
+                CourseID = courseId,
+                MentorID = mentorId,
+                GroupID = groupId,
+                ThemeID = themeId,
+                StudentAccountID = studentAccountId,
+                EventOccurrenceID = EventOccurenceId,
+                StartDate = startDate,
+                FinishDate = finishDate
+            };
+        }
+
         private void Initialize(CreateScheduleDto createScheduleDto)
         {
             _scheduleRepositoryMock.Setup(x => x.AddRange(new List<ScheduledEvent>()
@@ -406,6 +429,27 @@ namespace CharlieBackend.Api.UnitTest
             var result = await scheduleService.CreateScheduleAsync(createScheduleDto);
 
             //Assert
+            result.Should().NotBeNull();
+            result.Error.Code.Should().BeEquivalentTo(ErrorCode.ValidationError);
+        }
+
+        [Fact]
+        public async Task GetEventsFiltered_StartDateBiggerThanFinishDate_ShouldReturnValidationError()
+        {
+            // Arrange
+            var finishDate =  DateTime.Now;
+            var invalidStartDate = finishDate.AddDays(1);
+
+            var scheduledEventFilterDTO = Get_ScheduledEventFilterRequestDTO(
+                startDate: (DateTime?) invalidStartDate,
+                finishDate: (DateTime?) finishDate);
+
+            var scheduleService = new ScheduleService(_unitOfWorkMock.Object, _mapper, _scheduledEventFactory);
+
+            // Act
+            var result = await scheduleService.GetEventsFiltered(scheduledEventFilterDTO);
+
+            // Assert
             result.Should().NotBeNull();
             result.Error.Code.Should().BeEquivalentTo(ErrorCode.ValidationError);
         }

--- a/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
+++ b/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
@@ -374,7 +374,7 @@ namespace CharlieBackend.Business.Services
                 error.Append(" Theme does not exist");
             }
 
-            if (request.StartDate.HasValue && request.FinishDate.HasValue && (request.StartDate < request.FinishDate))
+            if (request.StartDate.HasValue && request.FinishDate.HasValue && (request.StartDate > request.FinishDate))
             {
                 error.Append($" StartDate must be less then FinisDate");
             }


### PR DESCRIPTION
There is a validator that should check that `StartDate` is < than `FinishDate`.
There was a wrong comparison operator.

* Fixed comparison operator in `ScheduleService.GetEventsFiltered()`
* Added unit test for this test case