### PR TITLE
Add method for POST requests in IApiUtil

### DIFF
--- a/CharlieBackend.AdminPanel/Utils/ApiUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/ApiUtil.cs
@@ -63,6 +63,19 @@ namespace CharlieBackend.AdminPanel.Utils
             return responseModel;
         }
 
+        public async Task<T1> PostAsync<T1, T2>(string url, T2 data)
+        {
+            var httpResponse = await _httpUtil.PostJsonAsync(url, data);
+
+            await _httpUtil.EnsureSuccessStatusCode(httpResponse);
+
+            string stringResponse = await httpResponse.Content.ReadAsStringAsync();
+
+            T1 responseModel = JsonConvert.DeserializeObject<T1>(stringResponse);
+
+            return responseModel;
+        }
+
         public async Task<T> PutAsync<T>(string url, T data)
         {
             var httpResponse = await _httpUtil.PutJsonAsync(url, data);

--- a/CharlieBackend.AdminPanel/Utils/Interfaces/IApiUtil.cs
+++ b/CharlieBackend.AdminPanel/Utils/Interfaces/IApiUtil.cs
@@ -11,6 +11,8 @@ namespace CharlieBackend.AdminPanel.Utils.Interfaces
 
         public Task<T> CreateAsync<T>(string url, T data);
 
+        public Task<T1> PostAsync<T1, T2>(string url, T2 data);
+
         public Task<T> PutAsync<T>(string url, T data);
 
         public Task<T> DeleteAsync<T>(string url);


### PR DESCRIPTION
* added new generic method `PostAsync<>()` in `IApiUtil`
* added it's implementation inside `ApiUtil`

The main reason for adding new method is that `IApiUtil` is lacking a method for POST requests with a different types of models for request and response.