### PR TITLE
Add services for calendar

### DIFF
--- a/CharlieBackend.AdminPanel/Controllers/CalendarController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/CalendarController.cs
@@ -1,0 +1,27 @@
+﻿using CharlieBackend.AdminPanel.Services.Interfaces;
+using CharlieBackend.Core.DTO.Schedule;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.AdminPanel.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class CalendarController : Controller
+    {
+        private readonly ICalendarService _calendarService;
+
+        public CalendarController(ICalendarService calendarService)
+        {
+            _calendarService = calendarService;
+        }
+
+        public async Task<IActionResult> Index(
+            ScheduledEventFilterRequestDTO scheduledEventFilter)
+        {
+            var data = await _calendarService.GetCalendarDataAsync(scheduledEventFilter);
+
+            return Ok(data);
+        }
+    }
+}

--- a/CharlieBackend.AdminPanel/Extensions/Extensions.cs
+++ b/CharlieBackend.AdminPanel/Extensions/Extensions.cs
@@ -1,0 +1,28 @@
+﻿using CharlieBackend.AdminPanel.Services;
+using CharlieBackend.AdminPanel.Services.Interfaces;
+using CharlieBackend.AdminPanel.Utils;
+using CharlieBackend.AdminPanel.Utils.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CharlieBackend.AdminPanel.Extensions
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Adding application's custom services into container for DI.
+        /// </summary>
+        public static void AddServices(this IServiceCollection services)
+        {
+            services.AddScoped<IHttpUtil, HttpUtil>();
+            services.AddScoped<IApiUtil, ApiUtil>();
+
+            services.AddScoped<IStudentService, StudentService>();
+            services.AddScoped<IStudentGroupService, StudentGroupService>();
+            services.AddScoped<ICourseService, CourseService>();
+            services.AddScoped<IMentorService, MentorService>();
+            services.AddScoped<IThemeService, ThemeService>();
+            services.AddScoped<IScheduleService, ScheduleService>();
+            services.AddScoped<ICalendarService, CalendarService>();
+        }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarCourseViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarCourseViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarCourseViewModel
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarEventOccurrenceViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarEventOccurrenceViewModel.cs
@@ -1,0 +1,18 @@
+﻿using CharlieBackend.Core.Entities;
+using System;
+
+namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarEventOccurrenceViewModel
+    {
+        public long? Id { get; set; }
+
+        public long StudentGroupId { get; set; }
+
+        public DateTime EventStart { get; set; }
+
+        public DateTime EventFinish { get; set; }
+
+        public PatternType Pattern { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarMentorViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarMentorViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarMentorViewModel
+    {
+        public long Id { get; set; }
+
+        public string Email { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarScheduledEventViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarScheduledEventViewModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarScheduledEventViewModel
+    {
+        public long Id { get; set; }
+
+        public long EventOccuranceId { get; set; }
+
+        public long StudentGroupId { get; set; }
+
+        public long? ThemeId { get; set; }
+
+        public long? MentorId { get; set; }
+
+        public long? LessonId { get; set; }
+
+        public DateTime EventStart { get; set; }
+
+        public DateTime EventFinish { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarStudentGroupViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarStudentGroupViewModel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarStudentGroupViewModel
+    {
+        public long Id { get; set; }
+
+        public long? CourseId { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime StartDate { get; set; }
+
+        public DateTime FinishDate { get; set; }
+
+        public IList<long> StudentIds { get; set; }
+
+        public IList<long> MentorIds { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarStudentViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarStudentViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarStudentViewModel
+    {
+        public long Id { get; set; }
+
+        public string Email { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarThemeViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarThemeViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarThemeViewModel
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Calendar/CalendarViewModel.cs
+++ b/CharlieBackend.AdminPanel/Models/Calendar/CalendarViewModel.cs
@@ -1,0 +1,24 @@
+﻿using CharlieBackend.Core.DTO.Schedule;
+using System.Collections.Generic;
+
+namespace CharlieBackend.AdminPanel.Models.Calendar
+{
+    public class CalendarViewModel
+    {
+        public IList<CalendarCourseViewModel> Courses { get; set; }
+
+        public IList<CalendarMentorViewModel> Mentors { get; set; }
+
+        public IList<CalendarStudentGroupViewModel> StudentGroups { get; set; }
+
+        public IList<CalendarStudentViewModel> Students { get; set; }
+
+        public IList<CalendarThemeViewModel> Themes { get; set; }
+
+        public IList<CalendarEventOccurrenceViewModel> EventOccurences { get; set; }
+
+        public IList<CalendarScheduledEventViewModel> ScheduledEvents { get; set; }
+
+        public ScheduledEventFilterRequestDTO ScheduledEventFilter { get; set; }
+    }
+}

--- a/CharlieBackend.AdminPanel/Models/Mapping/ViewModelMapping.cs
+++ b/CharlieBackend.AdminPanel/Models/Mapping/ViewModelMapping.cs
@@ -1,15 +1,16 @@
 ﻿using AutoMapper;
+using CharlieBackend.AdminPanel.Models.Calendar;
 using CharlieBackend.AdminPanel.Models.Course;
 using CharlieBackend.AdminPanel.Models.Mentor;
 using CharlieBackend.AdminPanel.Models.StudentGroups;
 using CharlieBackend.AdminPanel.Models.Students;
 using CharlieBackend.Core.DTO.Course;
+using CharlieBackend.Core.DTO.Mentor;
+using CharlieBackend.Core.DTO.Schedule;
 using CharlieBackend.Core.DTO.Student;
 using CharlieBackend.Core.DTO.StudentGroups;
-using System;
-using System.Collections.Generic;
+using CharlieBackend.Core.DTO.Theme;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace CharlieBackend.AdminPanel.Models.Mapping
 {
@@ -36,6 +37,16 @@ namespace CharlieBackend.AdminPanel.Models.Mapping
             CreateMap<MentorViewModel, MentorViewModel>();
 
             CreateMap<CourseDto, CourseViewModel>();
+
+            #region Calendar ViewModels mappings
+            CreateMap<CourseDto, CalendarCourseViewModel>();
+            CreateMap<MentorDto, CalendarMentorViewModel>();
+            CreateMap<StudentGroupDto, CalendarStudentGroupViewModel>();
+            CreateMap<StudentDto, CalendarStudentViewModel>();
+            CreateMap<ThemeDto, CalendarThemeViewModel>();
+            CreateMap<EventOccurrenceDTO, CalendarEventOccurrenceViewModel>();
+            CreateMap<ScheduledEventDTO, CalendarScheduledEventViewModel>();
+            #endregion
         }
     }
 }

--- a/CharlieBackend.AdminPanel/Services/CalendarService.cs
+++ b/CharlieBackend.AdminPanel/Services/CalendarService.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using CharlieBackend.AdminPanel.Models.Calendar;
+using CharlieBackend.AdminPanel.Services.Interfaces;
+using CharlieBackend.AdminPanel.Utils.Interfaces;
+using CharlieBackend.Core.DTO.Course;
+using CharlieBackend.Core.DTO.Mentor;
+using CharlieBackend.Core.DTO.Schedule;
+using CharlieBackend.Core.DTO.Student;
+using CharlieBackend.Core.DTO.StudentGroups;
+using CharlieBackend.Core.DTO.Theme;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.AdminPanel.Services
+{
+    /// <summary>
+    /// Class that provides methods for work with calendar and it's data.
+    /// </summary>
+    public class CalendarService : ICalendarService
+    {
+        private readonly IScheduleService _scheduleService;
+        private readonly IApiUtil _apiUtil;
+        private readonly IMapper _mapper;
+
+        private IList<CourseDto> _activeCourseDtos;
+        private IList<MentorDto> _activeMetorDtos;
+        private IList<StudentGroupDto> _studentGroupDtos;
+        private IList<StudentDto> _activeStudentDtos;
+        private IList<ThemeDto> _themeDtos;
+        private IList<EventOccurrenceDTO> _eventOccurrenceDtos;
+        private IList<ScheduledEventDTO> _scheduledEventDtos;
+        private ScheduledEventFilterRequestDTO _scheduledEventFilter;
+
+        private const int defaultDateFilterOffset = 15;
+
+        public CalendarService(
+            IScheduleService scheduleService,
+            IApiUtil apiUtil,
+            IMapper mapper)
+        {
+            _scheduleService = scheduleService;
+            _apiUtil = apiUtil;
+            _mapper = mapper;
+        }
+
+        public async Task<CalendarViewModel> GetCalendarDataAsync(
+            ScheduledEventFilterRequestDTO scheduledEventFilter)
+        {
+            ApplyEventFilter(scheduledEventFilter);
+
+            await GetDataFromApiAsync();
+
+            var calendarViewModel = InitCalendarViewModel();
+
+            return calendarViewModel;
+        }
+
+        /// <summary>
+        /// Applies default DateTime filter for scheduled events
+        /// in case it wasn't specified.
+        /// </summary>
+        private void ApplyEventFilter(
+            ScheduledEventFilterRequestDTO scheduledEventFilter)
+        {
+            if (!scheduledEventFilter.StartDate.HasValue)
+            {
+                scheduledEventFilter.StartDate = DateTime.Now.AddDays(-defaultDateFilterOffset);
+            }
+
+            if (!scheduledEventFilter.FinishDate.HasValue)
+            {
+                scheduledEventFilter.FinishDate = DateTime.Now.AddDays(defaultDateFilterOffset);
+            }
+
+            _scheduledEventFilter = scheduledEventFilter;
+        }
+
+        /// <summary>
+        /// Makes HTTP calls to Web API and obtains required data.
+        /// </summary>
+        private async Task GetDataFromApiAsync()
+        {
+            _activeCourseDtos = await _apiUtil.GetAsync<IList<CourseDto>>("api/courses/isActive");
+
+            _activeMetorDtos = await _apiUtil.GetAsync<IList<MentorDto>>("api/mentors/active");
+
+            _studentGroupDtos = await _apiUtil.GetAsync<IList<StudentGroupDto>>("api/student_groups");
+
+            _activeStudentDtos = await _apiUtil.GetAsync<IList<StudentDto>>("api/students/active");
+
+            _themeDtos = await _apiUtil.GetAsync<IList<ThemeDto>>("api/themes");
+
+            _eventOccurrenceDtos = await _scheduleService.GetAllEventOccurrences();
+
+            _scheduledEventDtos = await _scheduleService.GetEventsFiltered(_scheduledEventFilter);
+        }
+
+        /// <summary>
+        /// Initializes and returns new <see cref="CalendarViewModel"/> instance
+        /// with data obtained from Web API service.
+        /// </summary>
+        private CalendarViewModel InitCalendarViewModel()
+        {
+            return new CalendarViewModel
+            {
+                Courses = _mapper.Map<IList<CalendarCourseViewModel>>(_activeCourseDtos),
+                Mentors = _mapper.Map<IList<CalendarMentorViewModel>>(_activeMetorDtos),
+                StudentGroups = _mapper.Map<IList<CalendarStudentGroupViewModel>>(_studentGroupDtos),
+                Students = _mapper.Map<IList<CalendarStudentViewModel>>(_activeStudentDtos),
+                Themes = _mapper.Map<IList<CalendarThemeViewModel>>(_themeDtos),
+                EventOccurences = _mapper.Map<IList<CalendarEventOccurrenceViewModel>>(_eventOccurrenceDtos),
+                ScheduledEvents = _mapper.Map<IList<CalendarScheduledEventViewModel>>(_scheduledEventDtos),
+                ScheduledEventFilter = _scheduledEventFilter
+            };
+        }
+    }
+}

--- a/CharlieBackend.AdminPanel/Services/Interfaces/ICalendarService.cs
+++ b/CharlieBackend.AdminPanel/Services/Interfaces/ICalendarService.cs
@@ -1,0 +1,20 @@
+﻿using CharlieBackend.AdminPanel.Models.Calendar;
+using CharlieBackend.Core.DTO.Schedule;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.AdminPanel.Services.Interfaces
+{
+    /// <summary>
+    /// Interface that describes methods for work with calendar and it's data.
+    /// </summary>
+    public interface ICalendarService
+    {
+        /// <summary>
+        /// Method for obtaining calendar-related data.
+        /// </summary>
+        /// <param name="scheduledEventFilter">DTO with an optional set of 
+        /// filters for scheduled events.</param>
+        /// <returns>model with data required for viewing a calendar.</returns>
+        Task<CalendarViewModel> GetCalendarDataAsync(ScheduledEventFilterRequestDTO scheduledEventFilter);
+    }
+}

--- a/CharlieBackend.AdminPanel/Services/Interfaces/IScheduleService.cs
+++ b/CharlieBackend.AdminPanel/Services/Interfaces/IScheduleService.cs
@@ -1,0 +1,30 @@
+﻿using CharlieBackend.Core.DTO.Schedule;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.AdminPanel.Services.Interfaces
+{
+    /// <summary>
+    /// Interface that describes accessible methods to work with schedules.
+    /// </summary>
+    public interface IScheduleService
+    {
+        /// <summary>
+        /// Method for obtaining a collection of scheduled events
+        /// using given filter DTO.
+        /// </summary>
+        /// <param name="scheduledEventFilterDto">
+        /// DTO with a set of optional filtration parameters.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns>filtered collection of scheduled events.</returns>
+        Task<IList<ScheduledEventDTO>> GetEventsFiltered(
+            ScheduledEventFilterRequestDTO scheduledEventFilterDto);
+
+        /// <summary>
+        /// Method for obtaining a collection of all event occurrences.
+        /// </summary>
+        /// <returns>a collection of all event occurrences.</returns>
+        Task<IList<EventOccurrenceDTO>> GetAllEventOccurrences();
+    }
+}

--- a/CharlieBackend.AdminPanel/Services/ScheduleService.cs
+++ b/CharlieBackend.AdminPanel/Services/ScheduleService.cs
@@ -1,0 +1,45 @@
+﻿using CharlieBackend.AdminPanel.Services.Interfaces;
+using CharlieBackend.AdminPanel.Utils.Interfaces;
+using CharlieBackend.Core.DTO.Schedule;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.AdminPanel.Services
+{
+    /// <summary>
+    /// Class that provides methods for work with schedules.
+    /// </summary>
+    class ScheduleService : IScheduleService
+    {
+        private readonly IApiUtil _apiUtil;
+
+        public ScheduleService(IApiUtil apiUtil)
+        {
+            _apiUtil = apiUtil;
+        }
+
+        public async Task<IList<EventOccurrenceDTO>> GetAllEventOccurrences()
+        {
+            var result = await _apiUtil
+                .GetAsync<IList<EventOccurrenceDTO>>("/api/schedules/event-occurrences");
+
+            return result;
+        }
+
+        public async Task<IList<ScheduledEventDTO>> GetEventsFiltered(
+            ScheduledEventFilterRequestDTO scheduledEventFilterDto)
+        {
+            if (scheduledEventFilterDto is null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            var result = await _apiUtil.PostAsync<IList<ScheduledEventDTO>, ScheduledEventFilterRequestDTO>(
+                url: "api/schedules/events",
+                data: scheduledEventFilterDto);
+
+            return result;
+        }
+    }
+}

--- a/CharlieBackend.AdminPanel/Startup.cs
+++ b/CharlieBackend.AdminPanel/Startup.cs
@@ -1,13 +1,9 @@
 using AutoMapper;
+using CharlieBackend.AdminPanel.Extensions;
 using CharlieBackend.AdminPanel.Middlewares;
 using CharlieBackend.AdminPanel.Models.Mapping;
-using CharlieBackend.AdminPanel.Services;
-using CharlieBackend.AdminPanel.Services.Interfaces;
-using CharlieBackend.AdminPanel.Utils;
-using CharlieBackend.AdminPanel.Utils.Interfaces;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -25,7 +21,6 @@ namespace CharlieBackend.AdminPanel
             Configuration = configuration;
         }
 
-
         public void ConfigureServices(IServiceCollection services)
         {
             var config = Configuration.Get<ApplicationSettings>();
@@ -34,14 +29,7 @@ namespace CharlieBackend.AdminPanel
 
             services.AddHttpContextAccessor();
 
-            services.AddScoped<IHttpUtil, HttpUtil>();
-            services.AddScoped<IApiUtil, ApiUtil>();
-            
-            services.AddTransient<IStudentService, StudentService>(); 
-            services.AddTransient<IStudentGroupService, StudentGroupService>();
-            services.AddTransient<ICourseService, CourseService>();
-            services.AddTransient<IMentorService, MentorService>();
-            services.AddTransient<IThemeService, ThemeService>();
+            services.AddServices();
 
             // AutoMapper Configurations
             var mappingConfig = new MapperConfiguration(mc =>

--- a/CharlieBackend.Api/Controllers/SchedulesController.cs
+++ b/CharlieBackend.Api/Controllers/SchedulesController.cs
@@ -142,6 +142,20 @@ namespace CharlieBackend.Api.Controllers
         }
 
         /// <summary>
+        /// Gets all event occurrences
+        /// </summary>
+        /// <response code="200">Successfully returned a collection of event occurrences.</response>
+        [SwaggerResponse(200, type: typeof(IList<EventOccurrenceDTO>))]
+        [Authorize(Roles = "Secretary, Admin")]
+        [HttpGet("event-occurrences")]
+        public async Task<ActionResult<IList<EventOccurrenceDTO>>> GetAllEventOccurrences()
+        {
+            var eventOccurrences = await _scheduleService.GetEventOccurrencesAsync();
+
+            return eventOccurrences.ToActionResult();
+        }
+
+        /// <summary>
         /// Deletes exact schedule
         /// </summary>
         /// <remarks>

--- a/CharlieBackend.Business/Services/Interfaces/IScheduleService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/IScheduleService.cs
@@ -14,6 +14,8 @@ namespace CharlieBackend.Business.Services.Interfaces
 
         public Task<Result<EventOccurrenceDTO>> GetEventOccurrenceByIdAsync(long id);
 
+        public Task<Result<IList<EventOccurrenceDTO>>> GetEventOccurrencesAsync();
+
         public Task<Result<ScheduledEventDTO>> UpdateScheduledEventByID(long scheduledEvendID, UpdateScheduledEventDto scheduleModel);
 
         public Task<Result<IList<ScheduledEventDTO>>> UpdateEventsRange(ScheduledEventFilterRequestDTO filter, UpdateScheduledEventDto request);

--- a/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
+++ b/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
@@ -121,6 +121,14 @@ namespace CharlieBackend.Business.Services
                 Result<EventOccurrenceDTO>.GetSuccess(_mapper.Map<EventOccurrenceDTO>(scheduleEntity));
         }
 
+        public async Task<Result<IList<EventOccurrenceDTO>>> GetEventOccurrencesAsync()
+        {
+            var eventOccurences = await _unitOfWork.EventOccurrenceRepository.GetAllAsync();
+
+            return Result<IList<EventOccurrenceDTO>>.GetSuccess(
+                _mapper.Map<IList<EventOccurrenceDTO>>(eventOccurences));
+        }
+
         public async Task<Result<IList<ScheduledEventDTO>>> GetEventsFiltered(ScheduledEventFilterRequestDTO request)
         {
             string error = await ValidateGetEventsFilteredRequest(request);


### PR DESCRIPTION
With this commits I'm adding implementation to services that provide required data for calendar page (that is to be added in https://github.com/ita-social-projects/WhatBackend/issues/445).

Web API project:
* Added new endpoint to API: `api/events/event-occurrences` that returns all event occurrences

Admin panel:
* Added and implemented `IScheduleService`
* Added and implemented `ICalendarService`
* Added corresponding ViewModels & mappings for them