### PR TITLE
Added deleting single scheduled events by id

### DIFF
--- a/CharlieBackend.Api/Controllers/SchedulesController.cs
+++ b/CharlieBackend.Api/Controllers/SchedulesController.cs
@@ -175,5 +175,24 @@ namespace CharlieBackend.Api.Controllers
 
             return foundSchedules.ToActionResult();
         }
+
+        /// <summary>
+        /// Deletes concrete scheduled event by id
+        /// </summary>
+        /// <remarks>
+        /// Removes one concrete scheduled event related to specified EventOccurrence
+        /// Returns true if deleting was done, false in case scheduled event doesn't exist and error after the wrong request
+        /// </remarks>
+        /// <response code = "200" > Successful delete of schedule</response>
+        /// /// <response code="HTTP: 400, API: 0">Scheduled event does not exist</response>
+        /// <response code="HTTP: 409, API: 5">Can not delete scheduled event due to wrong request data</response>
+        [Authorize(Roles = "Secretary, Admin")]
+        [HttpDelete("events/{scheduledEventID}")]
+        public async Task<ActionResult> DeleteConcreteSchedule(long scheduledEventID)
+        {
+            var result = await _scheduleService.DeleteConcreteScheduleByIdAsync(scheduledEventID);
+
+            return result.ToActionResult();
+        }
     }
 }

--- a/CharlieBackend.Business/Services/Interfaces/IScheduleService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/IScheduleService.cs
@@ -22,6 +22,8 @@ namespace CharlieBackend.Business.Services.Interfaces
 
         public Task<Result<EventOccurrenceDTO>> DeleteScheduleByIdAsync(long studentGroupId, DateTime? startDate, DateTime? finishDate);
 
+        public Task<Result<bool>> DeleteConcreteScheduleByIdAsync(long id);
+
         public Task<Result<EventOccurrenceDTO>> UpdateEventOccurrenceById(long eventOccurrenceId, CreateScheduleDto request);
 
         public Task<Result<ScheduledEventDTO>> GetConcreteScheduleByIdAsync(long eventId);

--- a/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
+++ b/CharlieBackend.Business/Services/ScheduleServiceFolder/ScheduleService.cs
@@ -112,6 +112,27 @@ namespace CharlieBackend.Business.Services
             return Result<EventOccurrenceDTO>.GetSuccess(_mapper.Map<EventOccurrenceDTO>(eventOccurrenceResult));
         }
 
+        public async Task<Result<bool>> DeleteConcreteScheduleByIdAsync(long id)
+        {
+            if (id < 0)
+            {
+                return Result<bool>.GetError(ErrorCode.Conflict, 
+                    "Can not delete scheduled event due to wrong request data");
+            }
+
+            var scheduledEvent = await _unitOfWork.ScheduledEventRepository.GetByIdAsync(id);
+
+            if (scheduledEvent is null)
+            {
+                return Result<bool>.GetError(ErrorCode.ValidationError, "Scheduled event does not exist");
+            }
+
+            await _unitOfWork.ScheduledEventRepository.DeleteAsync(id);
+            await _unitOfWork.CommitAsync();
+
+            return Result<bool>.GetSuccess(true);
+        }
+
         public async Task<Result<EventOccurrenceDTO>> GetEventOccurrenceByIdAsync(long id)
         {
             var scheduleEntity = await _unitOfWork.EventOccurrenceRepository.GetByIdAsync(id);


### PR DESCRIPTION
When the scheduled event was successfully deleted result would be true. In case the user passed wrong data(less than zero) we didn't make a request to the database and returns the error 409. In case the scheduled event doesn't exist returned error 400. I would like to admit that all methods GetError return false as a result (if anyone has questions about it).

![111](https://user-images.githubusercontent.com/56502713/110627061-2cbded00-81aa-11eb-9b1d-9ee504ced6ee.png)
![222](https://user-images.githubusercontent.com/56502713/110627064-2def1a00-81aa-11eb-9487-437e039aed6f.png)
![333](https://user-images.githubusercontent.com/56502713/110627068-2e87b080-81aa-11eb-9165-63233177e78c.png)