### PR TITLE
Remove redundant Task.Run() calls

### DIFF
--- a/CharlieBackend.AdminPanel/Services/CalendarService.cs
+++ b/CharlieBackend.AdminPanel/Services/CalendarService.cs
@@ -53,13 +53,13 @@ namespace CharlieBackend.AdminPanel.Services
         {
             ApplyDefaultDateEventFilter(scheduledEventFilter);
 
-            var getCoursesTask = Task.Run(() => GetActiveCourseViewModelsAsync());
-            var getMentorsTask = Task.Run(() => GetActiveMetorViewModelsAsync());
-            var getStudentGroupsTask = Task.Run(() => GetStudentGroupViewModelsAsync());
-            var getStudentsTask = Task.Run(() => GetActiveStudentViewModelsAsync());
-            var getThemesTask = Task.Run(() => GetThemeViewModelsAsync());
-            var getEventOccurrencesTask = Task.Run(() => GetEventOccurrenceViewModelsAsync());
-            var getScheduledEventsTask = Task.Run(() => GetScheduledEventViewModelsAsync(scheduledEventFilter));
+            var getCoursesTask = GetActiveCourseViewModelsAsync();
+            var getMentorsTask = GetActiveMetorViewModelsAsync();
+            var getStudentGroupsTask = GetStudentGroupViewModelsAsync();
+            var getStudentsTask = GetActiveStudentViewModelsAsync();
+            var getThemesTask = GetThemeViewModelsAsync();
+            var getEventOccurrencesTask = GetEventOccurrenceViewModelsAsync();
+            var getScheduledEventsTask = GetScheduledEventViewModelsAsync(scheduledEventFilter);
 
             await Task.WhenAll(
                 new Task[] { getCoursesTask, getMentorsTask, getStudentGroupsTask, getStudentsTask,


### PR DESCRIPTION
[AdminPanel]
Addressing the https://github.com/ita-social-projects/WhatBackend/pull/460#discussion_r592158055
Removed redundant `Task.Run()` calls in data for calendar obtaining in `CalendarService.GetCalendarDataAsync()`