### PR TITLE
Remove redundant controller routes (Admin panel)

### DIFF
--- a/CharlieBackend.AdminPanel/Controllers/AccountController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/AccountController.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.DataProtection;
 
 namespace CharlieBackend.AdminPanel.Controllers
 {
-    [Route("[controller]/[action]")]
     public class AccountController : Controller
     {
         private readonly IOptions<ApplicationSettings> _config;

--- a/CharlieBackend.AdminPanel/Controllers/CoursesController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/CoursesController.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 namespace CharlieBackend.AdminPanel.Controllers
 {
-    [Route("[controller]/[action]")]
     public class CoursesController : Controller
     {
         private readonly ICourseService _courseService;

--- a/CharlieBackend.AdminPanel/Controllers/MentorsController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/MentorsController.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 namespace CharlieBackend.AdminPanel.Controllers
 {
     [Authorize(Roles = "Admin")]
-    [Route("[controller]/[action]")]
     public class MentorsController : Controller
     {
         private readonly IMentorService _mentorService;

--- a/CharlieBackend.AdminPanel/Controllers/StudentGroupController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/StudentGroupController.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 namespace CharlieBackend.AdminPanel.Controllers
 {
     [Authorize(Roles = "Admin")]
-    [Route("[controller]/[action]")]
     public class StudentGroupController : Controller
     {
         private readonly IStudentGroupService _studentGroupService;

--- a/CharlieBackend.AdminPanel/Controllers/StudentsController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/StudentsController.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Options;
 namespace CharlieBackend.AdminPanel.Controllers
 {
     [Authorize(Roles = "Admin")]
-    [Route("[controller]/[action]")]
     public class StudentsController : Controller
     {
         private readonly IStudentService _studentService;

--- a/CharlieBackend.AdminPanel/Controllers/ThemesController.cs
+++ b/CharlieBackend.AdminPanel/Controllers/ThemesController.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 namespace CharlieBackend.AdminPanel.Controllers
 {
     [Authorize(Roles = "Admin")]
-    [Route("[controller]/[action]")]
     public class ThemesController : Controller
     {
         private readonly IThemeService _themeService;


### PR DESCRIPTION
Removed redundant `Route` attributes from controllers in Admin panel.
All of these attributes had the default pattern (_Controller/Action/{id}_) that is already set in `Startup` class.