### PR TITLE
Move API endpoints for CourseService into ApplicationSettings

### DIFF
--- a/CharlieBackend.AdminPanel/ApplicationSettings.cs
+++ b/CharlieBackend.AdminPanel/ApplicationSettings.cs
@@ -14,6 +14,8 @@ namespace CharlieBackend.AdminPanel
     public class UrlsSettings
     {
         public ApiSettings Api { get; set; }
+
+        public ApiEndpoints ApiEndpoints { get; set; }
     }
 
     public class ApiSettings
@@ -21,6 +23,20 @@ namespace CharlieBackend.AdminPanel
         public string Http { get; set; }
 
         public string Https { get; set; }
+    }
+
+    public class ApiEndpoints
+    {
+        public CoursesApiEndpoints Courses { get; set; }
+    }
+
+    public class CoursesApiEndpoints
+    {
+        public string GetAllCoursesEndpoint { get; set; }
+        public string AddCourseEndpoint { get; set; }
+        public string UpdateCourseEndpoint { get; set; }
+        public string DisableCourseEndpoint { get; set; }
+        public string EnableCourseEndpoint { get; set; }
     }
 
     public class CookiesSettings

--- a/CharlieBackend.AdminPanel/Services/CourseService.cs
+++ b/CharlieBackend.AdminPanel/Services/CourseService.cs
@@ -3,6 +3,7 @@ using CharlieBackend.AdminPanel.Models.Course;
 using CharlieBackend.AdminPanel.Services.Interfaces;
 using CharlieBackend.AdminPanel.Utils.Interfaces;
 using CharlieBackend.Core.DTO.Course;
+using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,40 +15,59 @@ namespace CharlieBackend.AdminPanel.Services
 
         private readonly IMapper _mapper;
 
-        public CourseService(IApiUtil apiUtil, IMapper mapper)
+        private readonly CoursesApiEndpoints _coursesApiEndpoints;
+
+        public CourseService(
+            IApiUtil apiUtil, 
+            IMapper mapper, 
+            IOptions<ApplicationSettings> options)
         {
             _apiUtil = apiUtil;
             _mapper = mapper;
+            _coursesApiEndpoints = options.Value.Urls.ApiEndpoints.Courses;
         }
 
         public async Task<bool> DisableCourseAsync(long id)
         {
-            return await _apiUtil.DeleteAsync<bool>($"api/courses/{id}");
+            var disableCourseEndpoint = 
+                string.Format(_coursesApiEndpoints.DisableCourseEndpoint, id);
+
+            return await _apiUtil.DeleteAsync<bool>(disableCourseEndpoint);
         }
 
         public async Task<bool> EnableCourseAsync(long id)
         {
-            return await _apiUtil.EnableAsync<bool>($"api/courses/{id}");
+            var enableCourseEndpoint =
+                string.Format(_coursesApiEndpoints.EnableCourseEndpoint, id);
+
+            return await _apiUtil.EnableAsync<bool>(enableCourseEndpoint);
         }
 
         public async Task UpdateCourse(long id, UpdateCourseDto UpdateDto)
         {
+            var updateCourseEndpoint =
+                string.Format(_coursesApiEndpoints.UpdateCourseEndpoint, id);
+
             await
-                _apiUtil.PutAsync<UpdateCourseDto>($"api/courses/{id}", UpdateDto);
+                _apiUtil.PutAsync<UpdateCourseDto>(updateCourseEndpoint, UpdateDto);
         }
 
         public async Task<IList<CourseViewModel>> GetAllCoursesAsync()
         {
-            var courses = _mapper.Map<IList<CourseViewModel>>(await _apiUtil.GetAsync<IList<CourseDto>>($"api/courses/isActive"));
+            var getAllCoursesEndpoint =
+                string.Format(_coursesApiEndpoints.GetAllCoursesEndpoint);
 
-            return courses;
+            var courseDtos = await _apiUtil.GetAsync<IList<CourseDto>>(getAllCoursesEndpoint);
+
+            return _mapper.Map<IList<CourseViewModel>>(courseDtos);
         }
 
         public async Task AddCourseAsync(CreateCourseDto courseDto)
         {
-            await
-                _apiUtil.CreateAsync<CreateCourseDto>($"api/courses", courseDto);
-        }
+            var addCourseEndpoint =
+                string.Format(_coursesApiEndpoints.AddCourseEndpoint);
 
+            await _apiUtil.CreateAsync<CreateCourseDto>(addCourseEndpoint, courseDto);
+        }
     }
 }

--- a/CharlieBackend.AdminPanel/appsettings.json
+++ b/CharlieBackend.AdminPanel/appsettings.json
@@ -15,6 +15,15 @@
     "Api": {
       "Http": null,
       "Https": null
+    },
+    "ApiEndpoints": {
+      "Courses": {
+        "GetAllCoursesEndpoint": "api/courses/isActive",
+        "AddCourseEndpoint": "api/courses",
+        "UpdateCourseEndpoint": "api/courses/{0}",
+        "DisableCourseEndpoint": "api/courses/{0}",
+        "EnableCourseEndpoint": "api/courses/{0}"
+      }
     }
   },
 


### PR DESCRIPTION
Regarding the issue of hardcoded API endpoints inside services in AdminPanel: https://github.com/ita-social-projects/WhatBackend/issues/486

Moved these hardcoded strings from `CourseService` into _appsettings.json_. 
Now AdminPanel app reads them along the other settings and puts into `ApplicationSettings` class, that is now injected as a service.