### PR TITLE
Update mark for homework

### DIFF
--- a/CharlieBackend.Api.UnitTes/CharlieBackend.Api.UnitTest.csproj
+++ b/CharlieBackend.Api.UnitTes/CharlieBackend.Api.UnitTest.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MockQueryable.Moq" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/CharlieBackend.Api.UnitTes/HomeworkServiceTests.cs
+++ b/CharlieBackend.Api.UnitTes/HomeworkServiceTests.cs
@@ -288,62 +288,21 @@ namespace CharlieBackend.Api.UnitTest
         public async Task UpdateMarkAsync_ValidDataPassed_ShouldReturnExpectedData()
         {
             // Arrange
-            long lessonId = 1;
             sbyte mark = 5;
             sbyte updatedMark = 2;
             long visitId_one = 1;
             long visitId_two = 1;
-            long studentId_one = 1;
-            long studentId_two = 2;
-            long homeworkId = 1;
             long homeworkStudentId_one = 1;
             long homeworkStudentId_two = 1;
 
-            var visitTrue = CreateVisit(visitId_one, mark, true, studentId_one);
-            var visitFalse = CreateVisit(visitId_two, mark, false, studentId_two);
+            var visitTrue = CreateVisit(visitId_one, mark, true);
+            var visitFalse = CreateVisit(visitId_two, mark, false);
 
-            Lesson lesson = new Lesson()
-            {
-                Id = lessonId,
-                Visits = new List<Visit>()
-                {
-                   visitTrue,
-                   visitFalse
-                }
-            };
-
-            var homeworkStudent_one = new HomeworkStudent
-            {
-                Id = homeworkStudentId_one,
-                HomeworkId = homeworkId,
-                StudentId = studentId_one
-            };
-
-            var homeworkStudent_two = new HomeworkStudent
-            {
-                Id = homeworkStudentId_two,
-                HomeworkId = homeworkId,
-                StudentId = studentId_two
-            };
-
-            var homework = new Homework
-            {
-                LessonId = lessonId,
-                Id = homeworkId,
-                HomeworkStudents = new List<HomeworkStudent>
-                {
-                    homeworkStudent_one,
-                    homeworkStudent_two
-                }
-            };
+            var visitRepositoryMock = new Mock<IVisitRepository>();
 
             var lessonRepositoryMock = new Mock<ILessonRepository>();
             lessonRepositoryMock.Setup(x => x.GetVisitByStudentHomeworkIdAsync(homeworkStudentId_one)).ReturnsAsync(visitTrue);
             lessonRepositoryMock.Setup(x => x.GetVisitByStudentHomeworkIdAsync(homeworkStudentId_two)).ReturnsAsync(visitFalse);
-
-            var visitRepositoryMock = new Mock<IVisitRepository>();
-            visitRepositoryMock.Setup(x => x.GetByIdAsync(visitId_one)).ReturnsAsync(visitTrue);
-            visitRepositoryMock.Setup(x => x.GetByIdAsync(visitId_two)).ReturnsAsync(visitFalse);
 
             _unitOfWorkMock.Setup(x => x.LessonRepository).Returns(lessonRepositoryMock.Object);
             _unitOfWorkMock.Setup(x => x.VisitRepository).Returns(visitRepositoryMock.Object);
@@ -392,10 +351,8 @@ namespace CharlieBackend.Api.UnitTest
             long wrongHomeworkStudentId = 2;
 
             var lessonRepositoryMock = new Mock<ILessonRepository>();
-            var visitRepositoryMock = new Mock<IVisitRepository>();
 
             _unitOfWorkMock.Setup(x => x.LessonRepository).Returns(lessonRepositoryMock.Object);
-            _unitOfWorkMock.Setup(x => x.VisitRepository).Returns(visitRepositoryMock.Object);
 
             var homeworkService = new HomeworkService(
                 unitOfWork: _unitOfWorkMock.Object,

--- a/CharlieBackend.Api.UnitTes/RepositoriesTests/LessonRepositoryTests.cs
+++ b/CharlieBackend.Api.UnitTes/RepositoriesTests/LessonRepositoryTests.cs
@@ -1,0 +1,140 @@
+﻿using AutoMapper;
+using CharlieBackend.Business.Services;
+using CharlieBackend.Core.Entities;
+using CharlieBackend.Core.Mapping;
+using CharlieBackend.Data;
+using CharlieBackend.Data.Exceptions;
+using CharlieBackend.Data.Repositories.Impl;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CharlieBackend.Api.UnitTest.RepositoriesTests
+{
+    public class LessonRepositoryTests
+    {
+        [Fact]
+        public async Task UpdateMarkAsyncTest_ValidDataPassed_ShouldReturnVisit()
+        {
+            // Arrange
+            long lessonId = 1;
+            sbyte mark = 5;
+            long visitId_one = 1;
+            long visitId_two = 2;
+            long studentId_one = 1;
+            long studentId_two = 2;
+            long homeworkId = 1;
+            long homeworkStudentId_one = 1;
+            long homeworkStudentId_two = 2;
+
+            var visitTrue = new Visit
+            {
+                Id = visitId_one,
+                StudentMark = mark,
+                Presence = true,
+                StudentId = studentId_one
+            };
+            var visitFalse = new Visit
+            {
+                Id = visitId_two,
+                StudentMark = mark,
+                Presence = false,
+                StudentId = studentId_two
+            };
+
+            Lesson lesson = new Lesson()
+            {
+                Id = lessonId,
+                Visits = new List<Visit>()
+                {
+                   visitTrue,
+                   visitFalse
+                }
+            };
+
+            var homeworkStudent_one = new HomeworkStudent
+            {
+                Id = homeworkStudentId_one,
+                HomeworkId = homeworkId,
+                StudentId = studentId_one
+            };
+
+            var homeworkStudent_two = new HomeworkStudent
+            {
+                Id = homeworkStudentId_two,
+                HomeworkId = homeworkId,
+                StudentId = studentId_two,
+            };
+
+            var homework = new Homework
+            {
+                LessonId = lessonId,
+                Lesson = lesson,
+                Id = homeworkId,
+                HomeworkStudents = new List<HomeworkStudent>
+                {
+                    homeworkStudent_one,
+                    homeworkStudent_two
+                }
+            };
+
+            homeworkStudent_one.Homework = homework;
+            visitTrue.Lesson = lesson;
+
+            var options = new DbContextOptionsBuilder<ApplicationContext>()
+                .UseInMemoryDatabase(databaseName: "TestDatabase").Options;
+
+            using (var context = new ApplicationContext(options))
+            {
+                context.Database.EnsureCreated();
+                context.Lessons.Add(lesson);
+                context.Homeworks.Add(homework);
+                context.HomeworkStudents.Add(homeworkStudent_one);
+                context.HomeworkStudents.Add(homeworkStudent_two);
+                context.Visits.Add(visitFalse);
+                context.Visits.Add(visitTrue);
+                context.SaveChanges();
+            }
+
+            using (var context = new ApplicationContext(options))
+            {
+                var lessonRepository = new LessonRepository(context);
+
+                // Act
+                var foundVisitTrue = await lessonRepository.GetVisitByStudentHomeworkIdAsync(homeworkStudentId_one);
+                var foundVisitFalse = await lessonRepository.GetVisitByStudentHomeworkIdAsync(homeworkStudentId_two);
+
+                // Assert
+                foundVisitTrue.Id.Should().Equals(visitId_one);
+                foundVisitFalse.Id.Should().Equals(visitId_two);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateMarkAsyncTest_NoDataExisted_ShouldThrowException()
+        {
+            // Arrange
+            int wrongHomeworkStudentId = 1;
+            var options = new DbContextOptionsBuilder<ApplicationContext>()
+                .UseInMemoryDatabase(databaseName: "EmptyTestDatabase").Options;
+
+            using (var context = new ApplicationContext(options))
+            {
+                var lessonRepository = new LessonRepository(context);
+
+                // Act
+                Func<Task> wrongRequest = async () => await lessonRepository.GetVisitByStudentHomeworkIdAsync(wrongHomeworkStudentId);
+
+                // Assert
+                await wrongRequest.Should().ThrowAsync<NotFoundException>();
+            }
+        }
+
+    }
+}

--- a/CharlieBackend.Api/Controllers/HomeworksController.cs
+++ b/CharlieBackend.Api/Controllers/HomeworksController.cs
@@ -6,6 +6,7 @@ using CharlieBackend.Core.DTO.Homework;
 using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.AspNetCore.Annotations;
 using CharlieBackend.Business.Services.Interfaces;
+using CharlieBackend.Core.DTO.Visit;
 
 namespace CharlieBackend.Api.Controllers
 {
@@ -66,6 +67,19 @@ namespace CharlieBackend.Api.Controllers
                         .UpdateHomeworkAsync(id, updateHomeworkDto);
 
             return results.ToActionResult();
+        }
+
+        /// <summary>
+        /// Update student mark
+        /// </summary>
+        /// <response code="200">Successful updating of the mark</response>
+        /// <response code="HTTP: 404">Student homework not found</response>
+        [SwaggerResponse(200, type: typeof(VisitDto))]
+        [Authorize(Roles = "Admin, Mentor, Secretary")]
+        [HttpPut("updatemark")]
+        public async Task<ActionResult> UpdateMark([FromBody] UpdateMarkRequestDto request)
+        {
+            return (await _homeworkService.UpdateMarkAsync(request)).ToActionResult();
         }
     }
 }

--- a/CharlieBackend.Api/SwaggerExamples/HomeworksController/UpdateMarkRequest.cs
+++ b/CharlieBackend.Api/SwaggerExamples/HomeworksController/UpdateMarkRequest.cs
@@ -1,0 +1,17 @@
+﻿using CharlieBackend.Core.DTO.Homework;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace CharlieBackend.Api.SwaggerExamples.HomeworksController
+{
+    public class UpdateMarkRequest : IExamplesProvider<UpdateMarkRequestDto>
+    {
+        public UpdateMarkRequestDto GetExamples()
+        {
+            return new UpdateMarkRequestDto
+            {
+                StudentHomeworkId = 1,
+                StudentMark = 5
+            };
+        }
+    }
+}

--- a/CharlieBackend.Api/Validators/HomeworkDTOValidators/UpdateMarkRequestDtoValidator.cs
+++ b/CharlieBackend.Api/Validators/HomeworkDTOValidators/UpdateMarkRequestDtoValidator.cs
@@ -1,0 +1,24 @@
+﻿using CharlieBackend.Core.DTO.Homework;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CharlieBackend.Api.Validators.HomeworkDTOValidators
+{
+    public class UpdateMarkRequestDtoValidator : AbstractValidator<UpdateMarkRequestDto>
+    {
+        public UpdateMarkRequestDtoValidator()
+        {
+            RuleFor(x => x.StudentHomeworkId)
+                .NotNull()
+                .GreaterThan(0);
+
+            RuleFor(x => x.StudentMark)
+                .NotNull()
+                .GreaterThan(0)
+                .LessThan(100);
+        }
+    }
+}

--- a/CharlieBackend.Business/Services/HomeworkService.cs
+++ b/CharlieBackend.Business/Services/HomeworkService.cs
@@ -194,24 +194,14 @@ namespace CharlieBackend.Business.Services
 
         public async Task<Result<VisitDto>> UpdateMarkAsync(UpdateMarkRequestDto request)
         {
+            var visit = await _unitOfWork
+                                .LessonRepository
+                                .GetVisitByStudentHomeworkIdAsync(request
+                                    .StudentHomeworkId.GetValueOrDefault());
 
-            var studentHomework = await _unitOfWork.HomeworkStudentRepository
-                .GetByIdAsync(request.StudentHomeworkId.GetValueOrDefault());
-
-            if(studentHomework is null)
+            if (visit is null)
             {
-                throw new NotFoundException("Student homework does not exist");
-            }
-
-            var homework = await _unitOfWork.HomeworkRepository.GetByIdAsync(studentHomework.HomeworkId);
-
-            var visit = (await _unitOfWork.LessonRepository.GetByIdAsync(homework.LessonId))
-                .Visits
-                .FirstOrDefault(x => x.StudentId == studentHomework.StudentId);
-
-            if (studentHomework is null)
-            {
-                throw new NotFoundException("Student visit does not exist");
+                throw new NotFoundException($"Visit related to student howework with id {request.StudentHomeworkId} not found");
             }
 
             visit.StudentMark = (sbyte)request.StudentMark;

--- a/CharlieBackend.Business/Services/Interfaces/IHomeworkService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/IHomeworkService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using CharlieBackend.Core.Entities;
 using CharlieBackend.Core.DTO.Homework;
 using CharlieBackend.Core.Models.ResultModel;
+using CharlieBackend.Core.DTO.Visit;
 
 namespace CharlieBackend.Business.Services.Interfaces
 {
@@ -16,6 +17,8 @@ namespace CharlieBackend.Business.Services.Interfaces
         Task<Result<HomeworkDto>> UpdateHomeworkAsync(long homeworkId, HomeworkRequestDto updateHomeworkDto);
 
         Task<Result<IList<HomeworkDto>>> GetHomeworksByLessonId(long studentGroupId);
+
+        Task<Result<VisitDto>> UpdateMarkAsync(UpdateMarkRequestDto request);
 
     }
 }

--- a/CharlieBackend.Core/DTO/Homework/UpdateMarkRequestDto.cs
+++ b/CharlieBackend.Core/DTO/Homework/UpdateMarkRequestDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CharlieBackend.Core.DTO.Homework
+{
+    public class UpdateMarkRequestDto
+    {
+        public long? StudentHomeworkId { get; set; }
+        public int? StudentMark { get; set; }
+    }
+}

--- a/CharlieBackend.Core/Mapping/ModelMappingProfile.cs
+++ b/CharlieBackend.Core/Mapping/ModelMappingProfile.cs
@@ -213,6 +213,13 @@ namespace CharlieBackend.Core.Mapping
             CreateMap<HomeworkStudentDto, HomeworkStudent>();
 
             #endregion
+
+            #region Visit mapping
+
+            CreateMap<Visit, VisitDto>();
+            CreateMap<VisitDto, Visit>();
+
+            #endregion
         }
     }
 }

--- a/CharlieBackend.Data/Repositories/Impl/Interfaces/ILessonRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/Interfaces/ILessonRepository.cs
@@ -17,5 +17,7 @@ namespace CharlieBackend.Data.Repositories.Impl.Interfaces
         Task<List<Lesson>> GetLessonsForStudentAsync(long? studentGroupId, DateTime? startDate, DateTime? finishDate, long studentId);
 
         Task<Lesson> GetLessonByHomeworkId(long homeworkId);
+
+        Task<Visit> GetVisitByStudentHomeworkIdAsync(long studentHomeworkId);
     }
 }

--- a/CharlieBackend.Data/Repositories/Impl/LessonRepository.cs
+++ b/CharlieBackend.Data/Repositories/Impl/LessonRepository.cs
@@ -7,6 +7,7 @@ using CharlieBackend.Core.DTO.Lesson;
 using CharlieBackend.Data.Repositories.Impl.Interfaces;
 using CharlieBackend.Core;
 using System;
+using CharlieBackend.Data.Exceptions;
 
 namespace CharlieBackend.Data.Repositories.Impl
 {
@@ -108,6 +109,24 @@ namespace CharlieBackend.Data.Repositories.Impl
             return await _applicationContext.Lessons
                 .Include(x => x.Visits)
                 .FirstOrDefaultAsync(entity => entity.Id == id);
+        }
+
+        public async Task<Visit> GetVisitByStudentHomeworkIdAsync(long studentHomeworkId)
+        {
+            Visit visit = null;
+            try
+            {
+                visit = await _applicationContext.Visits.
+                    FirstAsync(visit => visit.Lesson.Homeworks
+                    .Any(hw => hw.HomeworkStudents
+                    .Any(hws => hws.Id == studentHomeworkId)));
+            }
+            catch
+            {
+                throw new NotFoundException($"Student howework with id {studentHomeworkId} not found");
+            }
+
+            return visit;
         }
     }
 }


### PR DESCRIPTION
Added endpoint UpdateMark to the HomeworkController. Now we can set a mark for student homework through updating StudentMark in visit, connected with a specific lesson, connected with specific homework, connected with specific student homework. If student homework or visit doesn't exist we get NotFoundExcepton. Also added unit tests for HomeworkService and LessonRepository (which allows us to get the visit for updating). 

![Screenshot_7](https://user-images.githubusercontent.com/56502713/113040752-d721a280-91a1-11eb-8473-2df002efd88c.png)
![Screenshot_8](https://user-images.githubusercontent.com/56502713/113040759-da1c9300-91a1-11eb-9ab6-34c4142f8b48.png)
![Screenshot_9](https://user-images.githubusercontent.com/56502713/113040764-dbe65680-91a1-11eb-9f16-04da551c0c97.png)
![Screenshot_10](https://user-images.githubusercontent.com/56502713/113040821-e9034580-91a1-11eb-9196-7f021434870e.png)



