### PR TITLE
Added uniqueness check for added theme

### DIFF
--- a/CharlieBackend.Business/Services/ThemeService.cs
+++ b/CharlieBackend.Business/Services/ThemeService.cs
@@ -26,10 +26,10 @@ namespace CharlieBackend.Business.Services
             {
                 var createdThemeEntity = _mapper.Map<Theme>(themeDto);
 
-                var Check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(createdThemeEntity.Name).Result;
+                var check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(createdThemeEntity.Name).Result;
 
 
-                if (Check == null)
+                if (check == null)
                 {
                     _unitOfWork.ThemeRepository.Add(createdThemeEntity);
 

--- a/CharlieBackend.Business/Services/ThemeService.cs
+++ b/CharlieBackend.Business/Services/ThemeService.cs
@@ -26,12 +26,23 @@ namespace CharlieBackend.Business.Services
             {
                 var createdThemeEntity = _mapper.Map<Theme>(themeDto);
 
-                _unitOfWork.ThemeRepository.Add(createdThemeEntity);
+                var Check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(createdThemeEntity.Name).Result;
 
-                await _unitOfWork.CommitAsync();
 
-                return Result<ThemeDto>
-                    .GetSuccess(_mapper.Map<ThemeDto>(createdThemeEntity));
+                if (Check == null)
+                {
+                    _unitOfWork.ThemeRepository.Add(createdThemeEntity);
+
+                    await _unitOfWork.CommitAsync();
+
+                    return Result<ThemeDto>
+                        .GetSuccess(_mapper.Map<ThemeDto>(createdThemeEntity));
+                }
+                else
+                {
+                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error");
+                }
+
             }
             catch
             {

--- a/CharlieBackend.Business/Services/ThemeService.cs
+++ b/CharlieBackend.Business/Services/ThemeService.cs
@@ -40,7 +40,7 @@ namespace CharlieBackend.Business.Services
                 }
                 else
                 {
-                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error");
+                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error: theme with such name already exists.");
                 }
 
             }


### PR DESCRIPTION
Attempt to add theme with name that already exists in database lead to Internal Server Error (code: 500).
With this check, attempt to add theme with same name leads to more appropriate validation error (code: 400). This can later be improved on.
Closes #817 