### PR TITLE
Added uniqueness check for theme during name update

### DIFF
--- a/CharlieBackend.Business/Services/ThemeService.cs
+++ b/CharlieBackend.Business/Services/ThemeService.cs
@@ -40,7 +40,7 @@ namespace CharlieBackend.Business.Services
                 }
                 else
                 {
-                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error");
+                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error: theme with such name already exists.");
                 }
 
             }
@@ -112,11 +112,19 @@ namespace CharlieBackend.Business.Services
                     return Result<ThemeDto>.GetError(ErrorCode.NotFound,
                         $"Theme with id={themeId} does not exist");
                 }
-                foundTheme.Name = themeDto.Name;
+                var check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(themeDto.Name).Result;
+                if (check == null)
+                {
+                    foundTheme.Name = themeDto.Name;
 
-                await _unitOfWork.CommitAsync();
+                    await _unitOfWork.CommitAsync();
 
-                return Result<ThemeDto>.GetSuccess(_mapper.Map<ThemeDto>(foundTheme));
+                    return Result<ThemeDto>.GetSuccess(_mapper.Map<ThemeDto>(foundTheme));
+                }
+                else
+                {
+                    return Result<ThemeDto>.GetError(ErrorCode.ValidationError, "Validation error: theme with such name already exists.");
+                }
             }
             catch
             {

--- a/CharlieBackend.Business/Services/ThemeService.cs
+++ b/CharlieBackend.Business/Services/ThemeService.cs
@@ -26,7 +26,7 @@ namespace CharlieBackend.Business.Services
             {
                 var createdThemeEntity = _mapper.Map<Theme>(themeDto);
 
-                var check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(createdThemeEntity.Name).Result;
+                var check = await _unitOfWork.ThemeRepository.GetThemeByNameAsync(createdThemeEntity.Name);
 
 
                 if (check == null)
@@ -112,7 +112,7 @@ namespace CharlieBackend.Business.Services
                     return Result<ThemeDto>.GetError(ErrorCode.NotFound,
                         $"Theme with id={themeId} does not exist");
                 }
-                var check = _unitOfWork.ThemeRepository.GetThemeByNameAsync(themeDto.Name).Result;
+                var check = await _unitOfWork.ThemeRepository.GetThemeByNameAsync(themeDto.Name);
                 if (check == null)
                 {
                     foundTheme.Name = themeDto.Name;


### PR DESCRIPTION
With this check (similar to one used in theme creation), updating theme name to one that is already being used lead to more appropriate "Validation error (code: 400)" instead of "Internal server error (code: 500)".